### PR TITLE
Add BigWigs Packager

### DIFF
--- a/.github/workflows/build-release.yml
+++ b/.github/workflows/build-release.yml
@@ -1,0 +1,25 @@
+name: Build and Release
+
+on:
+  push:
+    branches:
+      - main
+    tags:
+      - "*"
+
+jobs:
+  build:
+    runs-on: ubuntu-latest
+
+    env:
+      CF_API_KEY: ${{ secrets.CF_API_KEY }}
+      GITHUB_OAUTH: ${{ secrets.OAUTH_TOKEN }}
+      WAGO_API_TOKEN: ${{ secrets.WAGO_API_TOKEN }}
+
+    steps:
+      - uses: actions/checkout@v1
+        with:
+          fetch-depth: 150
+
+      - name: Package And Release
+        uses: BigWigsMods/packager@master

--- a/NorthernSkyRaidTools.toc
+++ b/NorthernSkyRaidTools.toc
@@ -1,13 +1,15 @@
 ## Interface: 110200
 
 ## Title: |cFF00FFFFNorthern Sky Raid Tools|r
-## Version: 1.0.0
+## Version: @project-version@
 ## IconTexture: Interface\AddOns\NorthernSkyRaidTools\Media\NSLogo.blp
 ## Author: Reloe, Rav
 ## DefaultState: Enable
 ## Dependencies: WeakAuras
 ## SavedVariables: NSRT
 ## Category: Northern Sky
+## X-Curse-Project-ID: 954018
+## X-Wago-ID: rN4VDdKD
 
 # Libraries
 Libs\libs.xml


### PR DESCRIPTION
Adds automatic packaging and pushing to CF / Wago / GH Release
Also makes it so that addon version number is taken from tag `## Version: @project-version@` 
CF and Wago project IDs should be correct in .toc afaik

Works similar how WA releases work. Tagged releases are "Release" and any kind of push to `main` branch is "Alpha" release

## Some keys that need to be added
All of these need to be added under repository settings 
![brave_6kgfBAEs5e](https://github.com/user-attachments/assets/8a33ea18-2fb8-424d-b5a4-4ae9d795b2c5)

- `CF_API_KEY` - from  https://legacy.curseforge.com/account/api-tokens 
- `WAGO_API_TOKEN` - from https://addons.wago.io/account/apikeys
- `OAUTH_TOKEN` - from https://github.com/settings/personal-access-tokens
   -  Setup permissions only to this repository and these permissions 
![image](https://github.com/user-attachments/assets/12a66372-700e-439b-b89d-0000c4d42267)

## Creating releases after this 
Alpha releases basically just work whenever you push anything to `main` branch. Their version number basically is last tag + commit id 

For Full releases you need to create tag and push it to repository. If you are using VS Code it's fairly simple "Ctrl+Shift+P" and "Git: Create Tag" and once that's done find "Git: Push Tags" and push to them to github and this action will start.


## Possible improvements

Libs can be removed from repository and pulled in during build process. Would need to setup `.pkgmeta ` file with all of them https://github.com/BigWigsMods/packager/wiki/Preparing-the-PackageMeta-File#including-external-libraries

Small issue with that is that you would not be able to just pull this repository and have addon working and would need to add all of these libs again, but they can be just copied from some release. But positive for that is that you wouldn't need to update them manually whenever there's some kind of update for them.