### PR TITLE
fix invitelist parsing to support Name-Realm format

### DIFF
--- a/Reminders.lua
+++ b/Reminders.lua
@@ -876,7 +876,7 @@ function NSI:InviteListFromReminder(str)
     local list = {}
     for line in str:gmatch('[^\r\n]+') do
         if line:find("invitelist:") then            
-            for name in line:gmatch("([%w%-]+)") do
+            for name in line:gmatch("([^%s,;:]+)") do
                 if name ~= "invitelist" then
                     table.insert(list, name)
                 end


### PR DESCRIPTION
In Reminders.lua:879, the pattern (%w+) only matches alphanumeric characters and doesn't include hyphens. So "Grohbert-Eredar" gets split into "Grohbert" and "Eredar" as separate names which then get tried to invite. 

I changed this, so the regexp also keeps the realmslugs (if existing) - so the invite also supports invites for characters from other realms.