### PR TITLE
feat(nicknames): add nickname support for DandersFrames

### DIFF
--- a/NSUI.lua
+++ b/NSUI.lua
@@ -1869,6 +1869,10 @@ function NSUI:Init()
             NSI:Grid2NickNameUpdated()
         end
 
+        if NSUI.OptionsChanged.nicknames["DANDERS_FRAMES_NICKNAMES"] then
+            NSI:DandersFramesNickNameUpdated(true)
+        end
+
         if NSUI.OptionsChanged.nicknames["UNHALTED_NICKNAMES"] then
             NSI:UnhaltedNickNameUpdated()
         end
@@ -2096,6 +2100,18 @@ Press 'Enter' to hear the TTS]],
             end,
             name = "Enable Grid2 Nicknames",
             desc = "Enable Nicknames to be used with Grid2 unit frames. This requires selecting the 'NSNickName' indicator within Grid2.",
+            nocombat = true
+        },
+        {
+            type = "toggle",
+            boxfirst = true,
+            get = function() return NSRT.Settings["DandersFrames"] end,
+            set = function(self, fixedparam, value)
+                NSUI.OptionsChanged.nicknames["DANDERS_FRAMES_NICKNAMES"] = true
+                NSRT.Settings["DandersFrames"] = value
+            end,
+            name = "Enable DandersFrames Nicknames",
+            desc = "Enable Nicknames to be used with DandersFrames unit frames.",
             nocombat = true
         },
         {

--- a/NickNames.lua
+++ b/NickNames.lua
@@ -116,6 +116,21 @@ function NSI:Grid2NickNameUpdated(all, unit)
      end
 end
 
+function NSI:DandersFramesNickNameUpdated(all, unit)
+    if DandersFrames then
+        if all then
+            DandersFrames:IterateCompactFrames(function(frame) 
+                DandersFrames:UpdateNameText(frame)
+            end)
+        elseif unit then
+            local frame = DandersFrames:GetFrameForUnit(unit)
+            if frame then
+                DandersFrames:UpdateNameText(frame)
+            end
+        end
+    end
+end
+
 -- Wipe NickName Database
 function NSI:WipeNickNames()
     self:WipeCellDB()
@@ -273,6 +288,7 @@ function NSI:UpdateNickNameDisplay(all, unit, name, realm, oldnick, nickname)
     self:ElvUINickNameUpdated()
     self:UnhaltedNickNameUpdated()
     self:BlizzardNickNameUpdated()
+    self:DandersFramesNickNameUpdated(all, unit)
 end
 
 function NSI:InitNickNames()
@@ -348,6 +364,13 @@ function NSI:InitNickNames()
             if tInsertUnique(CellDB.nicknames.list, name..":"..nickname) then
                 Cell.Fire("UpdateNicknames", "list-update", name, nickname)
             end
+        end
+    end
+
+    if DandersFrames then
+        function DandersFrames:GetUnitName(unit)
+            local name = UnitName(unit)
+            return name and NSAPI and NSAPI:GetName(name, "DandersFrames") or name
         end
     end
 end


### PR DESCRIPTION
Implementation overrides `DandersFrames:GetUnitName` (the recommended approach ref: DandersFrames/Core.luaL320).

Have only tested solo and in a party.

![WowB_5E6u53UJBK](https://github.com/user-attachments/assets/75ebba2c-4e2b-4803-b6ef-9935562ffb07)
![WowB_wglyoriwZF](https://github.com/user-attachments/assets/1024d4df-7dfb-4a0f-b7ff-f042b6c93214)
