### PR TITLE
Add useful reminder related slash commands

### DIFF
--- a/SlashCommands.lua
+++ b/SlashCommands.lua
@@ -31,6 +31,34 @@ SlashCmdList["NSUI"] = function(msg)
         else
             NSI.NSUI.cooldowns_frame:Show()
         end
+    elseif msg == "reminders" or msg == "r" then
+        if not NSUI.reminders_frame:IsShown() then
+            NSUI.reminders_frame:Show()
+        else
+            NSUI.reminders_frame:Hide()
+        end
+    elseif msg == "preminders" or msg == "pr" then
+        if not NSUI.personal_reminders_frame:IsShown() then
+            NSUI.personal_reminders_frame:Show()
+        else
+            NSUI.personal_reminders_frame:Hide()
+        end
+    elseif msg == "note" or msg == "n" then
+        NSRT.ReminderSettings.ShowReminderFrame = not NSRT.ReminderSettings.ShowReminderFrame
+        NSI:ProcessReminder()
+        NSI:UpdateReminderFrame()
+    elseif msg == "pnote" or msg == "pn" then
+        NSRT.ReminderSettings.ShowPersonalReminderFrame = not NSRT.ReminderSettings.ShowPersonalReminderFrame
+        NSI:ProcessReminder()
+        NSI:UpdateReminderFrame()
+    elseif msg == "clear" or msg == "c" then
+        NSRT.ActiveReminder = nil
+        NSI.Reminder = ""
+        NSI:ProcessReminder()
+
+        if NSRT.ReminderSettings.ShowReminderFrame then
+            NSI:UpdateReminderFrame()
+        end
     else
         NSI.NSUI:ToggleOptions()
     end


### PR DESCRIPTION
While using NSRT for the first time this raid week after moving from MRT I found myself missing some quick slash commands that I used often in MRT. I updated my NSRT to have them for myself and figured I'd open a PR to see if you were interested in taking any of them for the Addon.

Thanks for your work on NS WA's and now NSRT addon. It's very appreciated! 
