### PR TITLE
Update slash commands with new text note

### DIFF
--- a/SlashCommands.lua
+++ b/SlashCommands.lua
@@ -45,19 +45,33 @@ SlashCmdList["NSUI"] = function(msg)
             NSUI.personal_reminders_frame:Hide()
         end
     elseif msg == "note" or msg == "n" then
+        -- Toggle every note's frame
+
+        -- If they are out of sync, hide any that are visible to sync the frames first.
+        local visibility = not (NSRT.ReminderSettings.ShowReminderFrame or
+                                NSRT.ReminderSettings.ShowPersonalReminderFrame or
+                                NSRT.ReminderSettings.ShowExtraReminderFrame)
+
+        NSRT.ReminderSettings.ShowReminderFrame = visibility
+        NSRT.ReminderSettings.ShowPersonalReminderFrame = visibility
+        NSRT.ReminderSettings.ShowExtraReminderFrame = visibility
+        NSI:ProcessReminder()
+        NSI:UpdateReminderFrame(true, true, true)
+    elseif msg == "rnote" or msg == "rn" or msg == "anote" or msg == "an" then
+        -- Toggle the "Reminders Note" or "All Note"
         NSRT.ReminderSettings.ShowReminderFrame = not NSRT.ReminderSettings.ShowReminderFrame
         NSI:ProcessReminder()
-        NSI:UpdateReminderFrame(false)
+        NSI:UpdateReminderFrame(false, true, false)
     elseif msg == "pnote" or msg == "pn" then
+        -- Toggle the "Personal Note"
         NSRT.ReminderSettings.ShowPersonalReminderFrame = not NSRT.ReminderSettings.ShowPersonalReminderFrame
         NSI:ProcessReminder()
-        NSI:UpdateReminderFrame(true)
-    elseif msg == "clear" or msg == "c" then
-        NSRT.ActiveReminder = nil
-        NSI.Reminder = ""
+        NSI:UpdateReminderFrame(true, false, false)
+    elseif msg == "tnote" or msg == "tn" or msg == "enote" or msg == "en" then
+        -- Toggle the "Text Note" or "Extra Note"
+        NSRT.ReminderSettings.ShowExtraReminderFrame = not NSRT.ReminderSettings.ShowExtraReminderFrame
         NSI:ProcessReminder()
-
-        NSI:UpdateReminderFrame(false, true)
+        NSI:UpdateReminderFrame(false, false, true)
     else
         NSI.NSUI:ToggleOptions()
     end


### PR DESCRIPTION
- Added slash command to toggle new text / extra note
- Updated `/ns note` or `/ns n` to toggle all notes rather than the Reminder / All note
- Added slash command to toggle Reminder / All note
- Removed clear command as it's becoming more complicated with the three note types and buttons updating text in the frames. 

I believe the true/false flags for the `NSI:UpdateReminderFrame` is correct, but let me know if I messed those up. 