### PR TITLE
Update NickNames.lua

### DIFF
--- a/NickNames.lua
+++ b/NickNames.lua
@@ -343,6 +343,7 @@ function NSI:UpdateNickNameDisplay(all, unit, name, realm, oldnick, nickname)
     self:BlizzardNickNameUpdated()
     self:DandersFramesNickNameUpdated(all, unit)
     self:VuhDoNickNameUpdated()
+    self.Callbacks:Fire("NSRT_NICKNAME_UPDATED", all, unit, name, realm, oldnick, nickname)
 end
 
 function NSI:InitNickNames()


### PR DESCRIPTION
**Problem**
Currently, I can register for Nicknames, but if a user adds or deletes them a /reload is required for them to stick. Unless I register myself into your addon, have them click a checkbox, etc

**Solution**
Fire a callback

allows any addon to use Nicknames feature and you don't have to maintain them, they just add code to their project.

example:

```
-- [ NSRT NICKNAME CALLBACK ]------------------------------------------------------------------------
if NSAPI and NSAPI.RegisterCallback then
    NSAPI:RegisterCallback("NSRT_NICKNAME_UPDATED", function()
        if Orbit.EventBus then Orbit.EventBus:Fire("ORBIT_NICKNAMES_UPDATED") end
    end, "Orbit")
end
```


https://github.com/user-attachments/assets/7c5df088-349d-4274-937c-a3df62577498

once other addons use this, all that code can be deleted and won't need to be maintained, its on other addon developers to consume the event/callback 

