### PR TITLE
Beloren: fix feather icon and color swap enabled at same time

### DIFF
--- a/EncounterAlerts/MidnightS1/Beloren.lua
+++ b/EncounterAlerts/MidnightS1/Beloren.lua
@@ -149,7 +149,7 @@ NSI.EncounterAlertStart[encID] = function(self, id, preview) -- on ENCOUNTER_STA
         local s = NSRT.EncounterAlerts[encID][id]["Feather Color"]
 
         if not self.FeatherColorIconFrame then
-            self.FeatherColorIconFrame = CreateFrame("Frame", "NSRTFeatherColorIconFrame", self.NSRTFrame, "BackdropTemplate")
+            self.FeatherColorIconFrame = CreateFrame("Frame", "NSRTFeatherColorIconFrame", self.NSRTFrame)
             self.FeatherColorIconFrame.texture = self.FeatherColorIconFrame:CreateTexture("NSRTFeatherColorIconFrameTexture", "BACKGROUND")
             self.FeatherColorIconFrame.texture:SetAllPoints()
         end
@@ -166,30 +166,28 @@ NSI.EncounterAlertStart[encID] = function(self, id, preview) -- on ENCOUNTER_STA
             return
         end
 
-        self:EncounterRegister("UNIT_AURA", true, "player")
-        self.EncounterFrame:SetScript("OnEvent", function(_, e, unit, ...)
-            if e == "UNIT_AURA" then
-                local info = ...
-                if not info.addedAuras then return end
+        self.FeatherColorIconFrame:RegisterUnitEvent("UNIT_AURA", "player")
+        self.FeatherColorIconFrame:SetScript("OnEvent", function(_, e, ...)
+            local unit, info = ...
+            if not info.addedAuras then return end
 
-                self.FeatherColorIconFrame:Hide()
+            self.FeatherColorIconFrame:Hide()
 
-                -- all debuff aura instance IDs on us that we applied ourselves
-                local playerCastAuraInstanceIDsTest = {}
-                local playerCastAuraInstanceIDs = C_UnitAuras.GetUnitAuraInstanceIDs("player", "HARMFUL|PLAYER")
-                for _, auraInstanceID in ipairs(playerCastAuraInstanceIDs) do
-                    playerCastAuraInstanceIDsTest[auraInstanceID] = true
-                end
+            -- all debuff aura instance IDs on us that we applied ourselves
+            local playerCastAuraInstanceIDsTest = {}
+            local playerCastAuraInstanceIDs = C_UnitAuras.GetUnitAuraInstanceIDs("player", "HARMFUL|PLAYER")
+            for _, auraInstanceID in ipairs(playerCastAuraInstanceIDs) do
+                playerCastAuraInstanceIDsTest[auraInstanceID] = true
+            end
 
-                -- all debuff aura instance IDs on us, sorted by duration (infinite duration first)
-                local auras = C_UnitAuras.GetUnitAuras("player", "HARMFUL", 10, Enum.UnitAuraSortRule.ExpirationOnly, Enum.UnitAuraSortDirection.Reverse)
-                for _, aura in ipairs(auras) do
-                    -- first debuff we see that we didn't apply ourselves is probably the feather
-                    if not playerCastAuraInstanceIDsTest[aura.auraInstanceID] then
-                        self.FeatherColorIconFrame.texture:SetTexture(aura.icon)
-                        self.FeatherColorIconFrame:Show()
-                        return
-                    end
+            -- all debuff aura instance IDs on us, sorted by duration (infinite duration first)
+            local auras = C_UnitAuras.GetUnitAuras("player", "HARMFUL", 10, Enum.UnitAuraSortRule.ExpirationOnly, Enum.UnitAuraSortDirection.Reverse)
+            for _, aura in ipairs(auras) do
+                -- first debuff we see that we didn't apply ourselves is probably the feather
+                if not playerCastAuraInstanceIDsTest[aura.auraInstanceID] then
+                    self.FeatherColorIconFrame.texture:SetTexture(aura.icon)
+                    self.FeatherColorIconFrame:Show()
+                    return
                 end
             end
         end)
@@ -243,5 +241,6 @@ NSI.EncounterAlertStop[encID] = function(self, preview) -- on ENCOUNTER_END
             self:MakeDraggable(self.FeatherColorIconFrame, nil, false)
         end
         self.FeatherColorIconFrame:Hide()
+        self.FeatherColorIconFrame:UnregisterAllEvents()
     end
 end

--- a/EncounterAlerts/MidnightS1/Beloren.lua
+++ b/EncounterAlerts/MidnightS1/Beloren.lua
@@ -149,7 +149,7 @@ NSI.EncounterAlertStart[encID] = function(self, id, preview) -- on ENCOUNTER_STA
         local s = NSRT.EncounterAlerts[encID][id]["Feather Color"]
 
         if not self.FeatherColorIconFrame then
-            self.FeatherColorIconFrame = CreateFrame("Frame", "NSRTFeatherColorIconFrame", self.NSRTFrame)
+            self.FeatherColorIconFrame = CreateFrame("Frame", "NSRTFeatherColorIconFrame", self.NSRTFrame, "BackdropTemplate")
             self.FeatherColorIconFrame.texture = self.FeatherColorIconFrame:CreateTexture("NSRTFeatherColorIconFrameTexture", "BACKGROUND")
             self.FeatherColorIconFrame.texture:SetAllPoints()
         end

--- a/EncounterAlerts/MidnightS1/Beloren.lua
+++ b/EncounterAlerts/MidnightS1/Beloren.lua
@@ -166,28 +166,30 @@ NSI.EncounterAlertStart[encID] = function(self, id, preview) -- on ENCOUNTER_STA
             return
         end
 
-        self.FeatherColorIconFrame:RegisterUnitEvent("UNIT_AURA", "player")
-        self.FeatherColorIconFrame:SetScript("OnEvent", function(_, e, ...)
-            local unit, info = ...
-            if not info.addedAuras then return end
+        self:EncounterRegister("BelorenFeather", "UNIT_AURA", true, "player")
+        self:EncounterFunction("BelorenFeather", function(_, e, unit, ...)
+            if e == "UNIT_AURA" then
+                local info = ...
+                if not info.addedAuras then return end
 
-            self.FeatherColorIconFrame:Hide()
+                self.FeatherColorIconFrame:Hide()
 
-            -- all debuff aura instance IDs on us that we applied ourselves
-            local playerCastAuraInstanceIDsTest = {}
-            local playerCastAuraInstanceIDs = C_UnitAuras.GetUnitAuraInstanceIDs("player", "HARMFUL|PLAYER")
-            for _, auraInstanceID in ipairs(playerCastAuraInstanceIDs) do
-                playerCastAuraInstanceIDsTest[auraInstanceID] = true
-            end
+                -- all debuff aura instance IDs on us that we applied ourselves
+                local playerCastAuraInstanceIDsTest = {}
+                local playerCastAuraInstanceIDs = C_UnitAuras.GetUnitAuraInstanceIDs("player", "HARMFUL|PLAYER")
+                for _, auraInstanceID in ipairs(playerCastAuraInstanceIDs) do
+                    playerCastAuraInstanceIDsTest[auraInstanceID] = true
+                end
 
-            -- all debuff aura instance IDs on us, sorted by duration (infinite duration first)
-            local auras = C_UnitAuras.GetUnitAuras("player", "HARMFUL", 10, Enum.UnitAuraSortRule.ExpirationOnly, Enum.UnitAuraSortDirection.Reverse)
-            for _, aura in ipairs(auras) do
-                -- first debuff we see that we didn't apply ourselves is probably the feather
-                if not playerCastAuraInstanceIDsTest[aura.auraInstanceID] then
-                    self.FeatherColorIconFrame.texture:SetTexture(aura.icon)
-                    self.FeatherColorIconFrame:Show()
-                    return
+                -- all debuff aura instance IDs on us, sorted by duration (infinite duration first)
+                local auras = C_UnitAuras.GetUnitAuras("player", "HARMFUL", 10, Enum.UnitAuraSortRule.ExpirationOnly, Enum.UnitAuraSortDirection.Reverse)
+                for _, aura in ipairs(auras) do
+                    -- first debuff we see that we didn't apply ourselves is probably the feather
+                    if not playerCastAuraInstanceIDsTest[aura.auraInstanceID] then
+                        self.FeatherColorIconFrame.texture:SetTexture(aura.icon)
+                        self.FeatherColorIconFrame:Show()
+                        return
+                    end
                 end
             end
         end)
@@ -198,10 +200,9 @@ NSI.EncounterAlertStart[encID] = function(self, id, preview) -- on ENCOUNTER_STA
 
         self.channeling = false
 
-        self:EncounterRegister("UNIT_SPELLCAST_CHANNEL_START", true, "boss1")
-        self:EncounterRegister("UNIT_SPELLCAST_CHANNEL_STOP", true, "boss1")
-        self:EncounterRegister("ENCOUNTER_WARNING", true)
-        self.EncounterFrame:SetScript("OnEvent", function(_, e, ...)
+        self:EncounterRegister("BelorenColorSwap", {"UNIT_SPELLCAST_CHANNEL_START", "UNIT_SPELLCAST_CHANNEL_STOP", "ENCOUNTER_WARNING"}, true, "boss1")
+
+        self:EncounterFunction("BelorenColorSwap", function(_, e, ...)
             if e == "UNIT_SPELLCAST_CHANNEL_START" then
                 self.channeling = true
             elseif e == "UNIT_SPELLCAST_CHANNEL_STOP" then
@@ -241,6 +242,5 @@ NSI.EncounterAlertStop[encID] = function(self, preview) -- on ENCOUNTER_END
             self:MakeDraggable(self.FeatherColorIconFrame, nil, false)
         end
         self.FeatherColorIconFrame:Hide()
-        self.FeatherColorIconFrame:UnregisterAllEvents()
     end
 end

--- a/EncounterAlerts/MidnightS1/Beloren.lua
+++ b/EncounterAlerts/MidnightS1/Beloren.lua
@@ -200,7 +200,8 @@ NSI.EncounterAlertStart[encID] = function(self, id, preview) -- on ENCOUNTER_STA
 
         self.channeling = false
 
-        self:EncounterRegister("BelorenColorSwap", {"UNIT_SPELLCAST_CHANNEL_START", "UNIT_SPELLCAST_CHANNEL_STOP", "ENCOUNTER_WARNING"}, true, "boss1")
+        self:EncounterRegister("BelorenColorSwap", {"UNIT_SPELLCAST_CHANNEL_START", "UNIT_SPELLCAST_CHANNEL_STOP"}, true, "boss1")
+        self:EncounterRegister("BelorenColorSwap", "ENCOUNTER_WARNING", true)
 
         self:EncounterFunction("BelorenColorSwap", function(_, e, ...)
             if e == "UNIT_SPELLCAST_CHANNEL_START" then

--- a/EncounterAlerts/MidnightS1/LightblindedVanguard.lua
+++ b/EncounterAlerts/MidnightS1/LightblindedVanguard.lua
@@ -113,8 +113,8 @@ NSI.EncounterAlertStart[encID] = function(self, id)
             [6795]   = true, [355]   = true, [62124]  = true, [49576] = true,
         }
         local blacklist = {}
-        self:EncounterRegister("UNIT_SPELLCAST_SUCCEEDED", true, "player")
-        self.EncounterFrame:SetScript("OnEvent", function(_, e, u, _, spellID)
+        self:EncounterRegister("VanguardTaunts", "UNIT_SPELLCAST_SUCCEEDED", true, "player")
+        self:EncounterFunction("VanguardTaunts", function(_, e, u, _, spellID)
             if e == "UNIT_SPELLCAST_START" then
                 if not u:find("^nameplate%d") then return end
                 if not UnitIsEnemy("player", u) then return end
@@ -134,7 +134,7 @@ NSI.EncounterAlertStart[encID] = function(self, id)
                     self.TauntFrame.Text:Hide()
                     self.TauntTimersCancel = nil
                 end)
-                self:EncounterRegister("UNIT_SPELLCAST_START", false)
+                self:EncounterRegister("VanguardTaunts", "UNIT_SPELLCAST_START", false)
             elseif e == "UNIT_SPELLCAST_SUCCEEDED" and Taunts[spellID] then
                 if self.TauntTimersCancel then
                     self.TauntTimersCancel:Cancel()
@@ -146,9 +146,9 @@ NSI.EncounterAlertStart[encID] = function(self, id)
         self.TauntTimers = self.TauntTimers or {}
         for i, time in ipairs(info.timers) do
             self.TauntTimers[#self.TauntTimers+1] = C_Timer.NewTimer(time-3.1, function()
-                self:EncounterRegister("UNIT_SPELLCAST_START", true)
+                self:EncounterRegister("VanguardTaunts", "UNIT_SPELLCAST_START", true)
                 C_Timer.After(0.2, function()
-                    self:EncounterRegister("UNIT_SPELLCAST_START", false)
+                    self:EncounterRegister("VanguardTaunts", "UNIT_SPELLCAST_START", false)
                 end)
                 C_Timer.After(7, function()
                     blacklist = {}

--- a/EncounterAlerts/MidnightS1/MidnightFalls.lua
+++ b/EncounterAlerts/MidnightS1/MidnightFalls.lua
@@ -325,12 +325,9 @@ NSI.EncounterAlertStart[encID] = function(self, id, preview) -- on ENCOUNTER_STA
     end
     local interrupts = NSRT.EncounterAlerts[encID][id] and NSRT.EncounterAlerts[encID][id].InterruptDisplay
     if interrupts and interrupts.enabled and self:EvaluateLoad(interrupts) and realpull and id == 16 then
-        self:EncounterRegister("UNIT_SPELLCAST_START", true, {"boss2", "boss3", "boss4"})
-        self:EncounterRegister("UNIT_SPELLCAST_INTERRUPTED", true, {"boss2", "boss3", "boss4"})
-        self:EncounterRegister("UNIT_SPELLCAST_STOP", true, {"boss2", "boss3", "boss4"})
-        self:EncounterRegister("INSTANCE_ENCOUNTER_ENGAGE_UNIT", true)
+        self:EncounterRegister("InterruptDisplay", {"UNIT_SPELLCAST_START", "UNIT_SPELLCAST_INTERRUPTED", "UNIT_SPELLCAST_STOP", "INSTANCE_ENCOUNTER_ENGAGE_UNIT"}, true, {"boss2", "boss3", "boss4"})
         self:ReadInterruptNote(1)
-        self.EncounterFrame:SetScript("OnEvent", function(_, e, unit, ...)
+        self:EncounterFunction("InterruptDisplay", function(_, e, unit, ...)
             if e == "UNIT_SPELLCAST_START" then
                 if self.Interrupts.myTrackedID and unit == "boss"..self.Interrupts.myTrackedID and UnitIsEnemy(unit, "player") then
                     local info = {spellID = 1284934, dur = 2}
@@ -602,10 +599,7 @@ NSI.DetectPhaseChange[encID] = function(self, e, info)
             self.PhaseSwapTime = now
             if self.Phase == 2 and difficultyID == 16 then
                 self:HideInterrupt()
-                self:EncounterRegister("UNIT_SPELLCAST_START", false)
-                self:EncounterRegister("UNIT_SPELLCAST_INTERRUPTED", false)
-                self:EncounterRegister("UNIT_SPELLCAST_STOP", false)
-                self:EncounterRegister("INSTANCE_ENCOUNTER_ENGAGE_UNIT", false)
+                self:EncounterRegister("InterruptDisplay", {"UNIT_SPELLCAST_START", "UNIT_SPELLCAST_INTERRUPTED", "UNIT_SPELLCAST_STOP", "INSTANCE_ENCOUNTER_ENGAGE_UNIT"}, false)
                 if self.Interrupts then self.Interrupts.disabled = true end
             end
             if self.Phase == 4 and difficultyID == 16 then

--- a/EncounterAlerts/MidnightS1/MidnightFalls.lua
+++ b/EncounterAlerts/MidnightS1/MidnightFalls.lua
@@ -325,7 +325,8 @@ NSI.EncounterAlertStart[encID] = function(self, id, preview) -- on ENCOUNTER_STA
     end
     local interrupts = NSRT.EncounterAlerts[encID][id] and NSRT.EncounterAlerts[encID][id].InterruptDisplay
     if interrupts and interrupts.enabled and self:EvaluateLoad(interrupts) and realpull and id == 16 then
-        self:EncounterRegister("InterruptDisplay", {"UNIT_SPELLCAST_START", "UNIT_SPELLCAST_INTERRUPTED", "UNIT_SPELLCAST_STOP", "INSTANCE_ENCOUNTER_ENGAGE_UNIT"}, true, {"boss2", "boss3", "boss4"})
+        self:EncounterRegister("InterruptDisplay", {"UNIT_SPELLCAST_START", "UNIT_SPELLCAST_INTERRUPTED", "UNIT_SPELLCAST_STOP"}, true, {"boss2", "boss3", "boss4"})
+        self:EncounterRegister("InterruptDisplay", "INSTANCE_ENCOUNTER_ENGAGE_UNIT", true)
         self:ReadInterruptNote(1)
         self:EncounterFunction("InterruptDisplay", function(_, e, unit, ...)
             if e == "UNIT_SPELLCAST_START" then

--- a/EncounterAlerts/MidnightS1/Rotmire.lua
+++ b/EncounterAlerts/MidnightS1/Rotmire.lua
@@ -32,11 +32,8 @@ NSI.EncounterAlertStart[encID] = function(self) -- on ENCOUNTER_START
     if interrupts and interrupts.enabled and self:EvaluateLoad(interrupts) and id == 16 then
         self:ReadInterruptNote(1)
         if (not self.Interrupts.myTrackedID) or (not self.Interrupts.myTrackedID == 2) then return end
-        self:EncounterRegister("UNIT_SPELLCAST_START", true, "boss2")
-        self:EncounterRegister("UNIT_SPELLCAST_INTERRUPTED", true, "boss2")
-        self:EncounterRegister("UNIT_SPELLCAST_STOP", true, "boss2")
-        self:EncounterRegister("INSTANCE_ENCOUNTER_ENGAGE_UNIT", true)
-        self.EncounterFrame:SetScript("OnEvent", function(_, e, unit, ...)
+        self:EncounterRegister("InterruptDisplay", {"UNIT_SPELLCAST_START", "UNIT_SPELLCAST_INTERRUPTED", "UNIT_SPELLCAST_STOP", "INSTANCE_ENCOUNTER_ENGAGE_UNIT"}, true, "boss2")
+        self:EncounterFunction("InterruptDisplay", function(_, e, unit, ...)
             if e == "UNIT_SPELLCAST_START" then
                 if UnitIsEnemy(unit, "player") then
                     local info = {spellID = 1221714, dur = 6}

--- a/Functions.lua
+++ b/Functions.lua
@@ -514,25 +514,43 @@ function NSI:GetMySpecID()
     return C_SpecializationInfo.GetSpecializationInfo(C_SpecializationInfo.GetSpecialization()) or 0
 end
 
-function NSI:EncounterRegister(event, enable, units, all)
-    if not self.EncounterFrame then
-        self.EncounterFrame = CreateFrame("Frame", nil, self.NSRTFrame)
+function NSI:EncounterRegister(frameName, event, enable, units, all)
+    if not frameName then return end
+    if not self.EncounterFrames then
+        self.EncounterFrames = {}
     end
     if all then
-        self.EncounterFrame:UnregisterAllEvents()
+        for k, v in pairs(self.EncounterFrames) do
+            v:UnregisterAllEvents()
+        end
+        return
+    end
+    if event and not self.EncounterFrames[frameName] then
+        self.EncounterFrames[frameName] = CreateFrame("Frame", nil, self.NSRTFrame)
+    end
+    if event and type(event) == "table" then
+        for _, e in ipairs(event) do
+            self:EncounterRegister(frameName, e, enable, units)
+        end
         return
     end
     if enable then
         if units then
             if type(units) == "table" then
-                self.EncounterFrame:RegisterUnitEvent(event, units[1], units[2], units[3], units[4])
+                self.EncounterFrames[frameName]:RegisterUnitEvent(event, units[1], units[2], units[3], units[4])
             else
-                self.EncounterFrame:RegisterUnitEvent(event, units)
+                self.EncounterFrames[frameName]:RegisterUnitEvent(event, units)
             end
         else
-            self.EncounterFrame:RegisterEvent(event)
+            self.EncounterFrames[frameName]:RegisterEvent(event)
         end
     elseif event then
-        self.EncounterFrame:UnregisterEvent(event)
+        self.EncounterFrames[frameName]:UnregisterEvent(event)
+    end
+end
+
+function NSI:EncounterFunction(frameName, func)
+    if self.EncounterFrames and self.EncounterFrames[frameName] then
+        self.EncounterFrames[frameName]:SetScript("OnEvent", func)
     end
 end


### PR DESCRIPTION
Both modules were using ` self.EncounterFrame:SetScript("OnEvent", ...`, so the first one would get overwritten.
I just stuck the `UNIT_AURA` handler on `FeatherColorIconFrame ` and they can coexist now.