### PR TITLE
L'ura: Add seed drop timer

### DIFF
--- a/EncounterAlerts/MidnightS1/MidnightFalls.lua
+++ b/EncounterAlerts/MidnightS1/MidnightFalls.lua
@@ -67,7 +67,7 @@ NSI.InitializeMandatoryAlerts[encID] = function(self)
 
     local data = {
         internalID = "CrystalDropTimer",
-        name = "Crystal Drop Timer",
+        name = "Time to Pick Crystal",
         text = "PICK UP",
         DisplayType = "Bar",
         encID = encID,
@@ -79,7 +79,7 @@ NSI.InitializeMandatoryAlerts[encID] = function(self)
         customIcon = nil,
         difficulties = {14, 15, 16},
         timers = nil,
-        overrides = {pinned = true, BlockCopy = true},
+        overrides = {BlockCopy = true, enabled = false},
         HideTimer = false,
         MandatoryAlert = true,
     }
@@ -564,14 +564,10 @@ NSI.EncounterAlertStart[encID] = function(self, id, preview) -- on ENCOUNTER_STA
     end
 
     local crystalDropTimer = NSRT.EncounterAlerts[encID][id] and NSRT.EncounterAlerts[encID][id].CrystalDropTimer
-    if crystalDropTimer and ((crystalDropTimer.enabled and self:EvaluateLoad(crystalDropTimer) and not preview) or (preview and preview == "Crystal Drop Timer")) then
+    if crystalDropTimer and crystalDropTimer.enabled and self:EvaluateLoad(crystalDropTimer) and not preview then
         local s = NSRT.EncounterAlerts[encID][id].CrystalDropTimer
 
         local info = self:CreateReminder(CopyTable(s), true)
-        if preview then
-            self:DisplayReminder(info)
-            return
-        end
 
         self:EncounterRegister("CrystalDropTimer", "UNIT_SPELLCAST_SUCCEEDED", true, "player")
         self:EncounterFunction("CrystalDropTimer", function(_, e, unit, ...)

--- a/EncounterAlerts/MidnightS1/MidnightFalls.lua
+++ b/EncounterAlerts/MidnightS1/MidnightFalls.lua
@@ -64,6 +64,26 @@ NSI.InitializeMandatoryAlerts[encID] = function(self)
     end]],
     }
     self:AddEncounterAlert(data)
+
+    local data = {
+        internalID = "CrystalDropTimer",
+        name = "Crystal Drop Timer",
+        text = "PICK UP",
+        DisplayType = "Bar",
+        encID = encID,
+        phase = nil,
+        TTS = false,
+        dur = 5,
+        id = 0.2,
+        spellID = 1253050,
+        customIcon = nil,
+        difficulties = {14, 15, 16},
+        timers = nil,
+        overrides = {pinned = true, BlockCopy = true},
+        HideTimer = false,
+        MandatoryAlert = true,
+    }
+    self:AddEncounterAlert(data)
 end
 
 NSI.InitializeAlerts[encID] = function(self)
@@ -540,6 +560,26 @@ NSI.EncounterAlertStart[encID] = function(self, id, preview) -- on ENCOUNTER_STA
             HideAllRunes()
             self.AlertTimers[2] = nil
             self.LuraRunesCompleted = {}
+        end)
+    end
+
+    local crystalDropTimer = NSRT.EncounterAlerts[encID][id] and NSRT.EncounterAlerts[encID][id].CrystalDropTimer
+    if crystalDropTimer and ((crystalDropTimer.enabled and self:EvaluateLoad(crystalDropTimer) and not preview) or (preview and preview == "Crystal Drop Timer")) then
+        local s = NSRT.EncounterAlerts[encID][id].CrystalDropTimer
+
+        local info = self:CreateReminder(CopyTable(s), true)
+        if preview then
+            self:DisplayReminder(info)
+            return
+        end
+
+        self:EncounterRegister("CrystalDropTimer", "UNIT_SPELLCAST_SUCCEEDED", true, "player")
+        self:EncounterFunction("CrystalDropTimer", function(_, e, unit, ...)
+            local castGUID, spellID, castBarID = ...
+            -- Dawn Crystal
+            if spellID == 1253050 then
+                self:DisplayReminder(info)
+            end
         end)
     end
 end


### PR DESCRIPTION
Starts when you drop your seed and counts down to when it explodes (5 seconds?).
Considered cancelling it when you pick it back up, but that gets confusing when someone else picks it up, etc.

Not sure if the name is too close to the existing p2 stuff?