### PR TITLE
Escape sequence handling in Reminders.lua

### DIFF
--- a/Reminders.lua
+++ b/Reminders.lua
@@ -338,6 +338,8 @@ function NSI:ProcessReminder()
                 end
             else
                 if (not firstline) and (not line:find("invitelist:")) then
+                    -- Restore WoW color and icon escape sequences that get doubled when passing through an EditBox
+                    line = line:gsub("||c(%x%x%x%x%x%x%x%x)", "|c%1"):gsub("||r", "|r"):gsub("||T", "|T"):gsub("||t", "|t")
                     line = line:gsub("{(%a*%d*)}", function(token) -- convert {star}/{rt1} etc. to raid target icons
                         local id = symbols[token] or (token:match("^rt(%d)$") and tonumber(token:match("^rt(%d)$")))
                         if id then return "|TInterface\\TargetingFrame\\UI-RaidTargetingIcon_"..id..":0|t" end


### PR DESCRIPTION
Restore color and icon escape sequences in the note display

----------------

Note used for testing:
```
EncounterID:3306;Name:Chimaerus the Undreamt God - mythic;Difficulty:mythic
This is how you kill the boss:

- Do big damage {triangle}
- Don't die
- Boss HP should |cffC41F3Breach 0|r 
|T135939:14|t Priest > DPS


ph:1;time:14;tag:group1 group3 group5;dur:5;bossSpell:1262289;text:SOAK - Group 1 | 3;colors:1 0.5 0.1 1;DisplayType:Bar;
```

Before:
<img width="1470" height="787" alt="image" src="https://github.com/user-attachments/assets/ef08e396-b401-4c95-8399-1a818d14bfcd" />
<img width="410" height="308" alt="image" src="https://github.com/user-attachments/assets/2f01fc08-339f-48b5-9bc7-ad7860fcdc41" />


After: 
<img width="1468" height="786" alt="image" src="https://github.com/user-attachments/assets/309c852e-e73e-4672-8e25-b3378ce618db" />

<img width="417" height="322" alt="image" src="https://github.com/user-attachments/assets/efad4cc3-a388-4054-953d-8cf73d39eaaa" />