### PR TITLE
Lura Rune Display: cap sender width

### DIFF
--- a/EncounterAlerts/MidnightS1/MidnightFalls.lua
+++ b/EncounterAlerts/MidnightS1/MidnightFalls.lua
@@ -428,6 +428,8 @@ NSI.EncounterAlertStart[encID] = function(self, id, preview) -- on ENCOUNTER_STA
 
                 self.LuraRunesNumbers[pos] = self.LuraRunesFrame:CreateFontString(nil, "OVERLAY")
                 self.LuraRunesNumbers[pos]:SetTextColor(1, 1, 1)
+                self.LuraRunesNumbers[pos]:SetWidth(90)
+                self.LuraRunesNumbers[pos]:SetWordWrap(false)
                 self.LuraRunesNumbers[pos]:SetShadowColor(0, 0, 0, 1)
             end
             self.LuraRunesNumbers[pos]:SetFont(self:GetGlobalFontPath(), runes.ShowSenderNames and 16 or 25, "OUTLINE")


### PR DESCRIPTION
<img width="243" height="252" alt="image" src="https://github.com/user-attachments/assets/f99ae8d1-0165-46b2-ae03-8fe682375845" />

Its insanely long with off-realm people. Could do `ambiguate` in 12.0.7 but we're prob better off capping the name length in general.