### PR TITLE
fix: use GetRaidDifficultyID as fallback when leader is outside raid

### DIFF
--- a/SetupManager.lua
+++ b/SetupManager.lua
@@ -408,7 +408,8 @@ function NSI:SplitGroupInit(Flex, default, odds)
         if self.Groups.Processing and self.Groups.ProcessStart and now < self.Groups.ProcessStart + 15 then print("there is still a group process going on, please wait") return end
         if not self.LastGroupSort or self.LastGroupSort < now - 5 then
             self.LastGroupSort = GetTime()
-            local difficultyID = select(3, GetInstanceInfo()) or 0
+            local _, instanceType, difficultyID = GetInstanceInfo()
+            difficultyID = (instanceType == "raid" and difficultyID) or GetRaidDifficultyID() or 0
             if difficultyID == 16 then Flex = false else Flex = true end
             C_Timer.After(2, function() self:SortGroup(Flex, default, odds) end)
         else


### PR DESCRIPTION
GetInstanceInfo returns no useful difficulty when the player is not physically inside the instance. Fall back to GetRaidDifficultyID to get the configured raid difficulty, ensuring Mythic is correctly detected as 20-person (Flex=false) regardless of the leader's location.