### PR TITLE
Validate rune chat text before treating it as a rune report

### DIFF
--- a/EncounterAlerts/MidnightS1/MidnightFalls.lua
+++ b/EncounterAlerts/MidnightS1/MidnightFalls.lua
@@ -474,10 +474,16 @@ NSI.EncounterAlertStart[encID] = function(self, id, preview) -- on ENCOUNTER_STA
             self.LuraRunesFrame:Hide()
         end
 
+        local validRuneTexts = {
+            T = true, Circle = true, Diamond = true, Triangle = true, Cross = true,
+            ["134635"] = true, ["236903"] = true, ["340528"] = true, ["351033"] = true, ["7242384"] = true,
+        }
+
         if not self.LuraRunesFrame then
             self.LuraRunesFrame = CreateFrame("Frame", "nil", self.NSRTFrame, "BackdropTemplate")
         end
         self.LuraRunesFrame:SetScript("OnEvent", function(_, e, msg, ...)
+            if not validRuneTexts[msg] then return end
             if e == "CHAT_MSG_RAID" then
                 local sender = select(1, ...)
                 local senderGUID = select(11, ...)


### PR DESCRIPTION
Our raid group was having fun with the runes getting messed up when someone would smash text in their keyboard when they got hit by a glaive. This should fix that so it only listens to properly filtered text (the exact message symbols needed for the runes), so people can type things like "UGHHHH" during the run phase without breaking the display.