### PR TITLE
Fix vertical grow directions

### DIFF
--- a/NorthernSkyRaidTools/AuraTracking.lua
+++ b/NorthernSkyRaidTools/AuraTracking.lua
@@ -77,7 +77,10 @@ end
 local function GetAuraTrackingRowWidth(settings)
     local width = settings.Width or 1
     if settings.GrowDirection == "UP" or settings.GrowDirection == "DOWN" then
-        return width
+        local height = settings.Height or 1
+        local limit = settings.Limit or 1
+        local spacing = settings.Spacing or 0
+        return math.max(height, (height * limit) + (spacing * math.max(limit - 1, 0)))
     end
 
     local limit = settings.Limit or 1
@@ -1676,18 +1679,10 @@ local function InitAuraTrackingContainer(self, unit, settings, key, reconfigureB
     container:SetUnit(unit)
     local horizontalGrowthDirection, verticalGrowthDirection = GetAuraTrackingFlowDirections(settings.GrowDirection)
     local rowWidth = GetAuraTrackingRowWidth(settings)
-    local flowLayout = (container.GetFlowLayout and container:GetFlowLayout()) or container.flowLayout
-    if flowLayout then
-        flowLayout:SetLayoutAxis(GetAuraTrackingLayoutAxis(settings))
-        flowLayout:SetAnchorPoint(layoutAnchorPoint)
-        flowLayout:SetGrowthDirection(horizontalGrowthDirection, verticalGrowthDirection)
-        flowLayout:SetMaximumLineSize(rowWidth)
-    else
-        container.layoutAnchorPoint = layoutAnchorPoint
-        container.layoutHorizontalGrowthDirection = horizontalGrowthDirection
-        container.layoutVerticalGrowthDirection = verticalGrowthDirection
-        container.layoutRowWidth = rowWidth
-    end
+    container:SetFlowLayoutAxis(GetAuraTrackingLayoutAxis(settings))
+    container:SetFlowLayoutAnchorPoint(layoutAnchorPoint)
+    container:SetFlowLayoutGrowthDirection(horizontalGrowthDirection, verticalGrowthDirection)
+    container:SetFlowLayoutMaximumLineSize(rowWidth)
     if container.MarkDirty and AuraContainerDirtyMask then
         container:MarkDirty(AuraContainerDirtyMask.AuraFrameLayout)
     end


### PR DESCRIPTION
Up/down grow direction was broken: Left/right looked right by accident, since the anchor point happened to match the widget's default and the flow config itself was never actually applied. After that it wrapped to a new column after every icon instead of stacking.

  - `GetFlowLayout()` doesn't exist on `CustomAuraContainerTemplate`. Always nil, so it silently fell through to a dead `else` branch that just writes to fields nothing else ever reads.
  - `GetAuraTrackingRowWidth` returned a bare icon width for up/down instead of scaling by height/limit/spacing like the horizontal case already did, so even a correctly-set axis could only fit one icon per column before wrapping.

  Swapped the dead `GetFlowLayout` indirection for direct `SetFlowLayout*` calls on the container, and fixed row width to use `Height` for up/down.