### PR TITLE
Fix timeline preview placing note cues one phase early on bosses with .5 phase labels

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,4 @@
 ## Changelog
+- Fix timeline preview placing note cues one phase early on bosses with .5 phase labels (Nek'zali, The Coiled Altar)
 - Allow left clicking editboxes and make it more obvious you can edit numbers there
 - Add Placeholder Alerts for Nymrissa Wavecaller

--- a/NorthernSkyRaidTools/BossTimelines/BossTimelines.lua
+++ b/NorthernSkyRaidTools/BossTimelines/BossTimelines.lua
@@ -63,6 +63,17 @@ local _, NSI = ... -- Internal namespace
 -- Initialize the BossTimelines table
 NSI.BossTimelines = NSI.BossTimelines or {}
 
+-- Boss-mod phase LABELS in encounter order, for bosses whose labels are not
+-- plain 1..N. Note "ph:" values and live phase detection use these labels
+-- (1, 1.5, 2, ...), while BossTimelines.phases is keyed by contiguous segment
+-- index [1..N]: the k-th label corresponds to phases[k]. Encounters not listed
+-- here have labels identical to their segment indices. Trailing segments
+-- without a label (e.g. an end-of-fight marker) are display-only.
+NSI.BossPhaseLabels = {
+    [3470] = {1, 1.5, 2},    -- Nek'zali the Soulcoiler: Stage One, Ritual of Awakening, Stage Two
+    [3429] = {1, 2, 2.5, 3}, -- The Coiled Altar: Zul'jan, Hex Lord, Soul Bind, Coiled Union
+}
+
 -- Category colors for timeline display
 -- Maps category keywords to colors (supports compound categories like "raid damage, debuff")
 -- Colors match wowutils colorMap
@@ -298,7 +309,38 @@ function NSI:GetBossTimeline(encounterID, difficulty)
     return nil
 end
 
+-- Resolve a phase LABEL (as used in note "ph:" fields and live phase
+-- detection, e.g. 1.5) to its segment index in BossTimelines.phases.
+-- Returns nil for labels the encounter does not have.
+function NSI:PhaseLabelToSegment(encounterID, phaseLabel)
+    local labels = self.BossPhaseLabels[encounterID]
+    if not labels then return phaseLabel end
+    for segment, label in ipairs(labels) do
+        if label == phaseLabel then return segment end
+    end
+    return nil
+end
+
+-- Inverse of PhaseLabelToSegment. Returns nil for segments without a label
+-- (e.g. a trailing end-of-fight marker).
+function NSI:SegmentToPhaseLabel(encounterID, segmentIndex)
+    local labels = self.BossPhaseLabels[encounterID]
+    if not labels then return segmentIndex end
+    return labels[segmentIndex]
+end
+
+-- GetPhaseStart for a phase LABEL rather than a segment index. Never index
+-- BossTimelines.phases with a raw "ph:" value: on bosses with .5 labels the
+-- label and the segment index diverge (Nek'zali label 2 is segment 3).
+function NSI:GetPhaseLabelStart(encounterID, phaseLabel, difficulty)
+    local segment = self:PhaseLabelToSegment(encounterID, phaseLabel)
+    if not segment then return 0 end
+    return self:GetPhaseStart(encounterID, segment, difficulty)
+end
+
 -- Get user-adjusted phase start time, or default if not set
+-- phaseNum is a SEGMENT index into BossTimelines.phases, not a "ph:" label —
+-- use GetPhaseLabelStart to resolve note phase values.
 function NSI:GetPhaseStart(encounterID, phaseNum, difficulty)
     -- Phase 1 always starts at 0
     if phaseNum == 1 then return 0 end

--- a/NorthernSkyRaidTools_UI/Timeline.lua
+++ b/NorthernSkyRaidTools_UI/Timeline.lua
@@ -382,7 +382,7 @@ function NSI:GetMyTimelineData(includeBossAbilities, bossDisplayMode)
     -- Pre-calculate all phase start times for converting phase-relative times to absolute times
     local phaseStarts = {}
     for phase, _ in pairs(self.ProcessedReminder[encID]) do
-        phaseStarts[phase] = self:GetPhaseStart(encID, phase, reminderDifficulty) or 0
+        phaseStarts[phase] = self:GetPhaseLabelStart(encID, phase, reminderDifficulty) or 0
     end
 
     -- Iterate through all phases
@@ -557,19 +557,22 @@ function NSI:GetMyTimelineData(includeBossAbilities, bossDisplayMode)
     }, encID, phases, difficulty
 end
 
--- Return the phase number and its absolute start time for a given absolute time.
--- Picks the greatest phase start <= absoluteTime.
+-- Return the phase LABEL (the value used in note "ph:" fields, may be
+-- fractional like 1.5) and its absolute start time for a given absolute time.
+-- Picks the greatest phase start <= absoluteTime; segments without a label
+-- (trailing end-of-fight markers) are skipped.
 function NSI:PhaseFromTime(encID, absoluteTime, difficulty)
     local bestPhase = 1
     local bestStart = 0
     if encID then
         local timeline = self:GetBossTimeline(encID, difficulty)
         if timeline and timeline.phases then
-            for ph, _ in pairs(timeline.phases) do
-                local phStart = self:GetPhaseStart(encID, ph, difficulty)
-                if phStart <= absoluteTime and phStart >= bestStart then
+            for segment, _ in pairs(timeline.phases) do
+                local label = self:SegmentToPhaseLabel(encID, segment)
+                local phStart = self:GetPhaseStart(encID, segment, difficulty)
+                if label and phStart <= absoluteTime and phStart >= bestStart then
                     bestStart = phStart
-                    bestPhase = ph
+                    bestPhase = label
                 end
             end
         end
@@ -736,7 +739,7 @@ function NSI:GetAllTimelineData(reminderName, personal, includeBossAbilities, bo
     -- Pre-calculate phase start times for converting phase-relative times to absolute times
     local phaseStarts = {}
     for phase, _ in pairs(discoveredPhases) do
-        phaseStarts[phase] = encID and self:GetPhaseStart(encID, phase, reminderDifficulty) or 0
+        phaseStarts[phase] = encID and self:GetPhaseLabelStart(encID, phase, reminderDifficulty) or 0
     end
 
     -- Convert to timeline format
@@ -1724,7 +1727,7 @@ function NSI:CreateTimelineWindow()
                                 if bd and bd.payload and bd.payload.srcLineIndex and timelineWindow.editNote then
                                     local p = bd.payload
                                     local newRaw = p.srcRaw:gsub("time:[%d%.]+", "time:" .. newRelTime)
-                                    newRaw = newRaw:gsub("ph:%d+", "ph:" .. phase)
+                                    newRaw = newRaw:gsub("ph:%d*%.?%d+", "ph:" .. phase)
                                     NSI:RewriteNoteLine(timelineWindow.editNote.name, true, p.srcLineIndex, p.srcRaw, newRaw)
                                     -- Must be set BEFORE SetReminder: with skipupdate=false, SetReminder
                                     -- calls ProcessReminder(), which itself refreshes the timeline
@@ -2184,7 +2187,7 @@ function NSI:CreateTimelineWindow()
                     if bd and bd.payload and bd.payload.srcLineIndex and timelineWindow.editNote then
                         local p = bd.payload
                         local newRaw = p.srcRaw:gsub("time:[%d%.]+", "time:" .. newRelTime)
-                        newRaw = newRaw:gsub("ph:%d+", "ph:" .. phase)
+                        newRaw = newRaw:gsub("ph:%d*%.?%d+", "ph:" .. phase)
                         NSI:RewriteNoteLine(timelineWindow.editNote.name, true, p.srcLineIndex, p.srcRaw, newRaw)
                         -- Set before SetReminder — see the drag-retime comment above.
                         timelineWindow.preserveZoom = true
@@ -2811,7 +2814,8 @@ function NSI:UpdatePhaseMarkers()
                 -- Tooltip
                 marker:SetScript("OnEnter", function(self)
                     GameTooltip:SetOwner(self, "ANCHOR_RIGHT")
-                    local phaseName = phases[self.phaseNum] and phases[self.phaseNum].name or (T("Phase") .. " " .. self.phaseNum)
+                    local phaseLabel = NSI:SegmentToPhaseLabel(self.encID, self.phaseNum) or self.phaseNum
+                    local phaseName = phases[self.phaseNum] and phases[self.phaseNum].name or (T("Phase") .. " " .. phaseLabel)
                     local time = NSI:GetPhaseStart(self.encID, self.phaseNum)
                     local minutes = math.floor(time / 60)
                     local seconds = math.floor(time % 60)
@@ -3097,7 +3101,8 @@ function NSI:UpdateEmbeddedPhaseMarkers(tab)
 
                 marker:SetScript("OnEnter", function(self)
                     GameTooltip:SetOwner(self, "ANCHOR_RIGHT")
-                    local phaseName = phases[self.phaseNum] and phases[self.phaseNum].name or (T("Phase") .. " " .. self.phaseNum)
+                    local phaseLabel = NSI:SegmentToPhaseLabel(self.encID, self.phaseNum) or self.phaseNum
+                    local phaseName = phases[self.phaseNum] and phases[self.phaseNum].name or (T("Phase") .. " " .. phaseLabel)
                     local time = NSI:GetPhaseStart(self.encID, self.phaseNum)
                     local minutes = math.floor(time / 60)
                     local seconds = math.floor(time % 60)
@@ -3158,9 +3163,9 @@ function NSI:ShowReminderDialog(window, absoluteTime, block)
 
     -- Derive absolute time from the block's stored phase/time when not supplied
     if isEdit and not absoluteTime then
-        local phase   = tonumber(srcRaw:match("ph:(%d+)") or "1") or 1
+        local phase   = tonumber(srcRaw:match("ph:(%d*%.?%d+)") or "1") or 1
         local relTime = tonumber(srcRaw:match("time:(%d*%.?%d+)") or "0") or 0
-        local phStart = NSI:GetPhaseStart(window.currentEncounterID, phase, window.currentDifficulty) or 0
+        local phStart = NSI:GetPhaseLabelStart(window.currentEncounterID, phase, window.currentDifficulty) or 0
         absoluteTime  = phStart + relTime
     end
     absoluteTime = absoluteTime or 0
@@ -3402,15 +3407,16 @@ function NSI:ShowReminderDialog(window, absoluteTime, block)
 
         -- Phase / time-in-phase: manual override from the editable fields, falling
         -- back to the cursor/block-derived defaults if left blank or invalid.
-        local newPhase = math.max(1, math.floor(tonumber(popup.phaseEntry:GetValue()) or phase))
+        -- Phase is a boss-mod LABEL and may be fractional (1.5) — never floor it.
+        local newPhase = math.max(1, tonumber(popup.phaseEntry:GetValue()) or phase)
         local newRelTime = math.max(0, tonumber(popup.timeEntry:GetValue()) or relTime)
 
         if isEdit and payload and payload.srcLineIndex then
             -- Rebuild the line, preserving tag; updating time/ph/spell/text/dur/glowunit
             local newRaw = srcRaw
             newRaw = newRaw:gsub("time:[%d%.]+", "time:" .. newRelTime)
-            if newRaw:find("ph:%d+") then
-                newRaw = newRaw:gsub("ph:%d+", "ph:" .. newPhase)
+            if newRaw:find("ph:%d*%.?%d+") then
+                newRaw = newRaw:gsub("ph:%d*%.?%d+", "ph:" .. newPhase)
             else
                 newRaw = newRaw .. ";ph:" .. newPhase
             end


### PR DESCRIPTION
## Symptom

On Nek'zali (encounterID 3470), note cues written for the intermission (`ph:1.5`) render inside Stage One's window on the timeline preview, and cues written for Stage Two (`ph:2`) render inside the intermission's window. The same bug affects The Coiled Altar (encounterID 3429), whose phase labels are 1, 2, 2.5, 3.

In-combat reminder firing was already correct — a cue like `time:70;ph:1.5;...` fires 70s into the intermission as intended. Only the out-of-combat timeline/preview placement was wrong.

## Root cause

The note format's `ph:` value is the boss-mod phase **label** (1, 1.5, 2, ...), but `NSI.BossTimelines[encID].phases` is keyed by contiguous **segment index** [1..N] with no labels. The timeline placement indexed that table directly with the `ph:` value, so on Nek'zali `ph:2` hit `phases[2]` (the intermission segment) and `ph:1.5` hit nothing (start 0, i.e. Stage One). Several editor paths also integer-parsed the phase (`ph:(%d+)`, `math.floor`), corrupting `1.5` to `1`.

## Fix

- **`BossTimelines.lua`**: new `NSI.BossPhaseLabels` table mapping each affected encounter's phase-label sequence (the same one live phase detection uses) to segments in order — k-th label → segment [k]. Encounters not listed use labels identical to their segment indices, so plain 1..N bosses resolve exactly as before. New helpers `PhaseLabelToSegment` / `SegmentToPhaseLabel` / `GetPhaseLabelStart`; `GetPhaseStart` itself is unchanged and stays segment-index-based (markers, `NSRT.PhaseTimings` adjustments, boss ability data).
- **`Timeline.lua`**: note-cue placement (`GetMyTimelineData`, `GetAllTimelineData`) resolves `ph:` through `GetPhaseLabelStart` instead of raw indexing. `PhaseFromTime` now returns the **label** — so drag-retiming a cue writes the correct `ph:` value back into the note — and skips unlabeled trailing segments (Coiled Altar's end-of-fight marker at [5]). All `ph:` parse/rewrite patterns are fractional-safe (`ph:%d*%.?%d+`), and the edit dialog no longer floors the phase field. Phase marker tooltips show the label ("Phase 1.5") instead of the segment index.

The in-combat firing path is untouched.

## Verification

Ran the changed files (real `BossTimelines.lua` + data + `Timeline.lua`) under a standalone Lua harness with WoW API stubs — all placements verified, heroic and mythic:

| Case | Expected | Result |
|---|---|---|
| 3470 H `time:30;ph:1` | 0:30 | ✅ 30 |
| 3470 H `time:70;ph:1.5` | 248+70 = 318 | ✅ 318 |
| 3470 H `time:140;ph:2` | 437+140 = 577 | ✅ 577 |
| 3470 M `time:70;ph:1.5` | 102+70 = 172 | ✅ 172 |
| 3429 H `time:10;ph:2.5` | 392+10 = 402 | ✅ 402 |
| 3429 H `time:20;ph:3` | 427+20 = 447 | ✅ 447 |
| plain 1..N boss `ph:2` / no `ph:` | unchanged | ✅ |
| `PhaseFromTime` round-trips labels, skips end-of-fight segment | | ✅ |
| drag/edit rewrite keeps `ph:1.5` intact | | ✅ |
| user-adjusted `PhaseTimings` still apply through labels | | ✅ |

If you'd rather have WowUtils ship a `label` per segment in the generated BossTimelines data (e.g. `[2] = {start = 248, label = 1.5}`), the resolution helpers here can trivially switch to matching `segment.label` — happy to adjust.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
