### PR TITLE
Fix assignment reminders never reaching TimelineReminders

### DIFF
--- a/NorthernSkyRaidTools/EncounterAlerts/MidnightS1/Chimaerus.lua
+++ b/NorthernSkyRaidTools/EncounterAlerts/MidnightS1/Chimaerus.lua
@@ -45,7 +45,7 @@ NSI.AddAssignments[encID] = function(self, id) -- on ENCOUNTER_START
     if not diff then return end
     if diff == 16 and self.Assignments[encID].Soaks then
         local subgroup = self:GetSubGroup("player")
-        local Alert = self:CreateDefaultAlert("", "Text", nil, nil, 1, encID)
+        local Alert = self:CreateDefaultAlert("", "Text", nil, nil, 1, encID, true)
         Alert.dur, Alert.TTSTimer = 10, 5
         for phase = 1, 3 do
             Alert.phase = phase
@@ -66,7 +66,7 @@ NSI.AddAssignments[encID] = function(self, id) -- on ENCOUNTER_START
     elseif self.Assignments[encID].SplitSoaks and diff ~= 16 then
         if UnitGroupRolesAssigned("player") == "TANK" then return end
         local _, first = self:GetSortedGroup(true, false, false)
-        local Alert = self:CreateDefaultAlert("", "Text", nil, nil, 1, encID)
+        local Alert = self:CreateDefaultAlert("", "Text", nil, nil, 1, encID, true)
         local group = 2
         for i, v in ipairs(first) do
             if UnitIsUnit(v.unitid, "player") then group = 1; break end

--- a/NorthernSkyRaidTools/EncounterAlerts/MidnightS1/LightblindedVanguard.lua
+++ b/NorthernSkyRaidTools/EncounterAlerts/MidnightS1/LightblindedVanguard.lua
@@ -177,7 +177,7 @@ NSI.AddAssignments[encID] = function(self, id) -- on ENCOUNTER_START
     if not (self.Assignments and self.Assignments[encID] and self.Assignments[encID].Soaks) then return end
     if (not (id and id == 16)) and not self:DifficultyCheck({16}) then return end -- Mythic only
     local subgroup = self:GetSubGroup("player")
-    local Alert = self:CreateDefaultAlert("", "Text", nil, 8, 1, encID) -- text, Type, spellID, dur, phase, encID
+    local Alert = self:CreateDefaultAlert("", "Text", nil, 8, 1, encID, true) -- text, Type, spellID, dur, phase, encID
     local group = {}
     local healer = {}
     for unit in self:IterateGroupMembers() do

--- a/NorthernSkyRaidTools/EncounterAlerts/MidnightS1/VaelgorEzzorak.lua
+++ b/NorthernSkyRaidTools/EncounterAlerts/MidnightS1/VaelgorEzzorak.lua
@@ -77,7 +77,7 @@ NSI.AddAssignments[encID] = function(self, id) -- on ENCOUNTER_START
     local subgroup = self:GetSubGroup("player")
     if not subgroup then return end
     if UnitGroupRolesAssigned("player") == "TANK" then return end
-    local Soak = self:CreateDefaultAlert("", "Text", nil, 8, 1, encID)
+    local Soak = self:CreateDefaultAlert("", "Text", nil, 8, 1, encID, true)
     local timers = {14.2, 114.2, 213, 314.6, 409.7}
     for i, v in ipairs(timers) do
         Soak.time = v

--- a/NorthernSkyRaidTools/EncounterAlerts/MidnightS2/Sszorak.lua
+++ b/NorthernSkyRaidTools/EncounterAlerts/MidnightS2/Sszorak.lua
@@ -527,7 +527,7 @@ NSI.AddAssignments[encID] = function(self, id) -- on ENCOUNTER_START
         end
     end
 
-    local alert = self:CreateDefaultAlert("", "Text", nil, nil, 1, encID)
+    local alert = self:CreateDefaultAlert("", "Text", nil, nil, 1, encID, true)
     alert.dur = 6
     alert.TTSTimer = 0
     for _, timer in ipairs(tankComboTimers[diff]) do

--- a/NorthernSkyRaidTools/EncounterAlerts/MidnightS2/TheCoiledAltar.lua
+++ b/NorthernSkyRaidTools/EncounterAlerts/MidnightS2/TheCoiledAltar.lua
@@ -293,7 +293,7 @@ NSI.AddAssignments[encID] = function(self, id) -- on ENCOUNTER_START
     end
     for phase, timers in pairs({[1] = p1SoakTimers[diff], [3] = p3SoakTimers[diff]}) do
         if #timers > 0 then
-            local alert = self:CreateDefaultAlert("", "Text", nil, nil, phase, encID)
+            local alert = self:CreateDefaultAlert("", "Text", nil, nil, phase, encID, true)
             alert.dur = 8
             for index, timer in ipairs(timers) do
                 local shouldSoak = (index == 1 and group == 1) or (index == 2 and group == 2)

--- a/NorthernSkyRaidTools/Reminders.lua
+++ b/NorthernSkyRaidTools/Reminders.lua
@@ -2244,7 +2244,7 @@ function NSI:CreateDefaultAlert(text, DisplayType, spellID, dur, phase, encID) -
         phase = phase or self.Phase,
         id = id,
         startTime = GetTime(),
-        IsAssignment = IsAssignment,
+        IsAssignment = true,
         countdown = false,
         DisplayType = DisplayType,
     }

--- a/NorthernSkyRaidTools/Reminders.lua
+++ b/NorthernSkyRaidTools/Reminders.lua
@@ -2229,7 +2229,7 @@ function NSAPI:DebugTimeline(e, dur)
     NSRT.Settings.Debug = current
 end
 
-function NSI:CreateDefaultAlert(text, DisplayType, spellID, dur, phase, encID) -- only used for Assignments now
+function NSI:CreateDefaultAlert(text, DisplayType, spellID, dur, phase, encID, isAssignment) -- only used for Assignments now
     local id = self.DefaultAlertID or 10000
     self.DefaultAlertID = self.DefaultAlertID and self.DefaultAlertID + 1 or 10001
     local info =
@@ -2244,7 +2244,7 @@ function NSI:CreateDefaultAlert(text, DisplayType, spellID, dur, phase, encID) -
         phase = phase or self.Phase,
         id = id,
         startTime = GetTime(),
-        IsAssignment = true,
+        IsAssignment = isAssignment,
         countdown = false,
         DisplayType = DisplayType,
     }


### PR DESCRIPTION
CreateDefaultAlert sets IsAssignment from an undefined global, so it's always nil. Assignments are therefore never handed to TimelineReminders, and users displaying the NSRT note through TL have them suppressed entirely. Setting it to true restores the intended routing.