### PR TITLE
Expanded on profile API, adding existence check, delete and main prof…

### DIFF
--- a/NorthernSkyRaidTools/Profiles.lua
+++ b/NorthernSkyRaidTools/Profiles.lua
@@ -757,6 +757,30 @@ function NSI:ExportProfileString(includeSharedData)
     return self:EncodeExportData(exportTable)
 end
 
+function NSAPI:ProfileExists(name)
+    return name and NSRT.Profiles and NSRT.Profiles[name] ~= nil
+end
+
+function NSAPI:DeleteProfile(name)
+    if not name then return false end
+    if not NSRT.Profiles or not NSRT.Profiles[name] then
+        return false
+    end
+
+    NSI:DeleteProfile(name)
+    return true
+end
+
+function NSAPI:SetMainProfile(name)
+    if not name then return false end
+    if not NSRT.Profiles or not NSRT.Profiles[name] then
+        return false
+    end
+
+    NSI:SetMainProfile(name)
+    return true
+end
+
 function NSAPI:ImportProfileString(importString, name, allowSharedData) -- name is optional
     local exportTable = NSI:DecodeExportData(importString)
     if type(exportTable) ~= "table" then return nil end


### PR DESCRIPTION
**Building on the existing NSAPI:ImportProfileString() API, it would be useful to expose a few additional profile management methods for third-party addons.**

**In particular, an API to:**

- check whether a profile exists,
- delete an existing profile before importing a new version, and
- set a specific profile as the Main Profile.

This makes it easier for addons to manage their own NSRT profiles and update them cleanly without having to access NSRT's internal profile tables directly (for instance by altering savedvariables :x ).

The existing internal functionality already supports these operations, so this would primarily expose it through the public NSAPI.
This should make profile importing and updating more convenient and reliable for third-party addons in general.

_On a sidenote: It might also be interesting to make the import/export API more modular, allowing specific parts of the profile data to be included or excluded, such as Shared Notes or Personal Notes._