### PR TITLE
add a nicknames toggle for Spotlights

### DIFF
--- a/NorthernSkyRaidTools_UI/UI/Options/Nicknames.lua
+++ b/NorthernSkyRaidTools_UI/UI/Options/Nicknames.lua
@@ -242,6 +242,18 @@ local function BuildNicknamesOptions()
             desc = "Enable Nicknames to be used with EllesmereUI unit frames.",
             nocombat = true
         },
+        {
+            type = "toggle",
+            boxfirst = true,
+            get = function() return NSRT.Settings["Spotlights"] end,
+            set = function(self, fixedparam, value)
+                NSRT.Settings["Spotlights"] = value
+                NSI:FireCallback("SPOTLIGHTS_NICKNAME_TOGGLE", value)
+            end,
+            name = "Enable Spotlights Nicknames",
+            desc = "Enable Nicknames to be used with Spotlights unit frames.",
+            nocombat = true
+        },
 
         {
             type = "breakline"


### PR DESCRIPTION
Spotlights is my Unit Frame addon for singling out individual players: https://www.curseforge.com/wow/addons/spotlights.

I was asked to add support to NSRT for nicknames: 
<img width="716" height="163" alt="image" src="https://github.com/user-attachments/assets/ce1891c1-9198-447f-af06-33c895c409f0" />

Off:
<img width="1393" height="546" alt="image" src="https://github.com/user-attachments/assets/07fc9c53-9df5-48d4-a1dd-5f9d9c8f2ca9" />
<img width="1244" height="630" alt="image" src="https://github.com/user-attachments/assets/4e80aaa4-8e92-4227-8650-51dc950b7346" />

On:
<img width="1579" height="706" alt="image" src="https://github.com/user-attachments/assets/44611819-ec72-479d-bc80-a76217845a78" />
