### PR TITLE
extend ulatek buff list settings

### DIFF
--- a/NorthernSkyRaidTools/AuraTracking.lua
+++ b/NorthernSkyRaidTools/AuraTracking.lua
@@ -1972,42 +1972,42 @@ local function ConfigureDebuffOverviewButton(self, state, button, unit)
     button:SetMouseMotionEnabled(false)
 end
 
-function NSI:CreateDebuffOverviewContainers(regularFilter, candidateFilters, containersPerUnit, maxFrameCount, containerName, invertFill, useBarColorAsBackground, useApplicationBar, maxApplications, overrides, sortByDuration)
-    containerName = containerName or "Default"
-    self.DebuffOverviewContainerSetsByName = self.DebuffOverviewContainerSetsByName or {}
-    local existingSet = self.DebuffOverviewContainerSetsByName[containerName]
-    if existingSet then
-        if useApplicationBar ~= nil or maxApplications ~= nil or overrides or sortByDuration ~= nil then
-            for _, state in ipairs(existingSet) do
-                if useApplicationBar ~= nil then state.useApplicationBar = useApplicationBar == true end
-                state.maxApplications = maxApplications or state.maxApplications
-                if sortByDuration ~= nil then state.sortByDuration = sortByDuration == true end
-                state.height = overrides and overrides.height or state.height
-                state.barColors = overrides and overrides.barColors or state.barColors
-                state.backgroundColors = overrides and overrides.backgroundColors or state.backgroundColors
-            end
-            if overrides and self.DebuffOverviewContainerPreviewActive and self.DebuffOverviewContainerPreviewName == containerName and self.DebuffOverviewFakePreviewConfig then
-                self.DebuffOverviewFakePreviewConfig.overrides = overrides
-                self.DebuffOverviewFakePreviewConfig.backgroundOnly = overrides.backgroundOnly
-            end
-        end
-        self.DebuffOverviewContainerSets = existingSet
-        self:UpdateDebuffOverviewContainers()
-        return existingSet
-    end
-    if regularFilter == nil and candidateFilters == nil then
-        return self.DebuffOverviewContainerSetsByName[containerName]
-    end
-    assert(type(regularFilter) == "string" and AuraUtil.IsValidFilterString(regularFilter), "regularFilter must be a valid aura filter string")
-    assert(candidateFilters == nil or type(candidateFilters) == "table", "candidateFilters must be a table or nil")
-    if not C_AddOns.IsAddOnLoaded("Blizzard_AuraContainer") then
-        C_AddOns.LoadAddOn("Blizzard_AuraContainer")
-    end
-
+local function EnsureDebuffOverviewBaseRow(self, state)
     local settings = NSRT.ReminderSettings.DebuffOverviewSettings
-    local anchor = self.DebuffOverviewMover
-    local copies = math.max(1, math.floor(containersPerUnit or 1))
-    local frameCount = maxFrameCount or 1
+    local container = state.container
+    local row = state.baseRow
+    if not row then
+        row = CreateFrame("StatusBar", nil, container:GetParent(), "BackdropTemplate")
+        row:SetFrameStrata(container:GetFrameStrata())
+        row:SetFrameLevel(math.max(container:GetFrameLevel() - 1, 0))
+        row:SetBackdrop({bgFile = "Interface\\Buttons\\WHITE8x8"})
+        row.Border = CreateFrame("Frame", nil, row, "BackdropTemplate")
+        row.Border:SetAllPoints(row)
+        row.Border:SetBackdrop({edgeFile = "Interface\\Buttons\\WHITE8x8", edgeSize = 1})
+        row.Name = row:CreateFontString(nil, "OVERLAY")
+        row:Hide()
+        state.baseRow = row
+    end
+    local height = state.height or settings.Height
+    local barOffset = settings.IconPosition == "Right" and 0 or height
+    row:SetSize(settings.Width + height, height)
+    row:SetBackdropColor(unpack(state.inactiveColors or state.backgroundColors or settings.backgroundColors))
+    row.Border:SetBackdropBorderColor(unpack(settings.borderColors))
+    row.Name:ClearAllPoints()
+    row.Name:SetPoint("LEFT", row, "LEFT", barOffset + settings.xTextOffset, settings.yTextOffset)
+    row.Name:SetFont(self.LSM:Fetch("font", settings.Font), settings.FontSize, settings.FontFlags)
+    row.Name:SetTextColor(unpack(settings.textColors))
+    row.Name:SetText(state.displayName)
+    return row
+end
+
+-- NSI.spectable: tank, melee, range, healer
+local function GetDebuffOverviewRolePriority(self, unit)
+    local specID = self:GetSpecs(unit)
+    return specID and self.spectable[specID] or 100
+end
+
+local function GetDebuffOverviewFlow(settings)
     local growDirection = settings.GrowDirection or "Up"
     local flowHorizontal = AnchorUtil.FlowDirection.Right
     local flowVertical = AnchorUtil.FlowDirection.Down
@@ -2022,11 +2022,162 @@ function NSI:CreateDebuffOverviewContainers(regularFilter, candidateFilters, con
     elseif growDirection == "Left" then
         flowHorizontal = AnchorUtil.FlowDirection.Left
         flowAnchor = "TOPRIGHT"
-    elseif growDirection == "Right" then
-        flowHorizontal = AnchorUtil.FlowDirection.Right
-        flowAnchor = "TOPLEFT"
     end
-    local previousContainer
+    return growDirection, flowAxis, flowAnchor, flowHorizontal, flowVertical
+end
+
+-- overrides.subgroups is an array of raid subgroup numbers ({1, 2, 3, 4}); nil means all subgroups, an empty array means none
+local function BuildDebuffOverviewSubgroupFilter(subgroups)
+    if type(subgroups) ~= "table" then return nil end
+    local filter = {}
+    for _, subgroup in ipairs(subgroups) do
+        local index = tonumber(subgroup)
+        if index then filter[index] = true end
+    end
+    return filter
+end
+
+local function AnchorDebuffOverviewRow(frame, growDirection, previous, anchor, spacing, xOffset, yOffset)
+    frame:ClearAllPoints()
+    if previous then
+        if growDirection == "Up" then
+            frame:SetPoint("BOTTOMLEFT", previous, "TOPLEFT", 0, spacing)
+        elseif growDirection == "Down" then
+            frame:SetPoint("TOPLEFT", previous, "BOTTOMLEFT", 0, -spacing)
+        elseif growDirection == "Left" then
+            frame:SetPoint("TOPRIGHT", previous, "TOPLEFT", -spacing, 0)
+        else
+            frame:SetPoint("TOPLEFT", previous, "TOPRIGHT", spacing, 0)
+        end
+    elseif growDirection == "Up" then
+        frame:SetPoint("BOTTOMLEFT", anchor, "TOPLEFT", xOffset, 8)
+    elseif growDirection == "Down" then
+        frame:SetPoint("TOPLEFT", anchor, "BOTTOMLEFT", xOffset, -8)
+    elseif growDirection == "Left" then
+        frame:SetPoint("TOPRIGHT", anchor, "TOPLEFT", -8, yOffset)
+    else
+        frame:SetPoint("TOPLEFT", anchor, "TOPRIGHT", 8, yOffset)
+    end
+end
+
+local function DebuffOverviewUnitMatchesSet(state)
+    if not UnitIsVisible(state.unit) then return false end
+    if not state.subgroups then return true end
+    local subgroup = select(3, GetRaidRosterInfo(state.raidIndex))
+    return (subgroup and state.subgroups[subgroup]) == true
+end
+
+function NSI:LayoutDebuffOverviewSets()
+    local sets = self.DebuffOverviewContainerSetsByName
+    local anchor = self.DebuffOverviewMover
+    if not sets or not anchor then return end
+    local settings = NSRT.ReminderSettings.DebuffOverviewSettings
+    local growDirection, _, flowAnchor = GetDebuffOverviewFlow(settings)
+    local vertical = growDirection == "Up" or growDirection == "Down"
+    local spacing = settings.Spacing or 0
+    local shownSets = self.DebuffOverviewShownSets or {}
+    local setOffset = 0
+
+    for _, containerName in ipairs(self.DebuffOverviewContainerOrder or {}) do
+        local states = sets[containerName]
+        if states and states[1] then
+            local setShown = shownSets[containerName]
+            local sortByRole = states[1].sortByRole
+            local height = states[1].height or settings.Height
+            local ordered = {}
+            for _, state in ipairs(states) do
+                local visible = setShown and DebuffOverviewUnitMatchesSet(state)
+                state.visible = visible
+                if visible then
+                    state.sortPriority = sortByRole and GetDebuffOverviewRolePriority(self, state.unit) or state.raidIndex
+                    ordered[#ordered + 1] = state
+                end
+            end
+            table.sort(ordered, function(a, b)
+                if a.sortPriority == b.sortPriority then return a.raidIndex < b.raidIndex end
+                return a.sortPriority < b.sortPriority
+            end)
+
+            local xOffset = vertical and setOffset or 0
+            local yOffset = vertical and 0 or -setOffset
+            local previousContainer, previousRow
+            for _, state in ipairs(ordered) do
+                local container, row = state.container, state.baseRow
+                if state.showInactive and row then
+                    AnchorDebuffOverviewRow(row, growDirection, previousRow, anchor, spacing, xOffset, yOffset)
+                    row:Show()
+                    previousRow = row
+                    container:ClearAllPoints()
+                    container:SetPoint(flowAnchor, row, flowAnchor)
+                else
+                    AnchorDebuffOverviewRow(container, growDirection, previousContainer, anchor, spacing, xOffset, yOffset)
+                    previousContainer = container
+                    if row then row:Hide() end
+                end
+                container:SetShown(true)
+                container:SetEnabled(true)
+            end
+            for _, state in ipairs(states) do
+                if not state.visible then
+                    state.container:SetShown(false)
+                    state.container:SetEnabled(false)
+                    if state.baseRow then state.baseRow:Hide() end
+                end
+            end
+            if #ordered > 0 then
+                setOffset = setOffset + (vertical and (settings.Width + height + spacing) or (height + spacing))
+            end
+        end
+    end
+end
+
+function NSI:CreateDebuffOverviewContainers(regularFilter, candidateFilters, containersPerUnit, maxFrameCount, containerName, invertFill, useBarColorAsBackground, useApplicationBar, maxApplications, overrides, sortByDuration)
+    containerName = containerName or "Default"
+    self.DebuffOverviewContainerSetsByName = self.DebuffOverviewContainerSetsByName or {}
+    self.DebuffOverviewContainerOrder = self.DebuffOverviewContainerOrder or {}
+    local existingSet = self.DebuffOverviewContainerSetsByName[containerName]
+    if existingSet then
+        if useApplicationBar ~= nil or maxApplications ~= nil or overrides or sortByDuration ~= nil then
+            for _, state in ipairs(existingSet) do
+                if useApplicationBar ~= nil then state.useApplicationBar = useApplicationBar == true end
+                state.maxApplications = maxApplications or state.maxApplications
+                if sortByDuration ~= nil then state.sortByDuration = sortByDuration == true end
+                state.height = overrides and overrides.height or state.height
+                state.barColors = overrides and overrides.barColors or state.barColors
+                state.backgroundColors = overrides and overrides.backgroundColors or state.backgroundColors
+                state.inactiveColors = overrides and overrides.inactiveColors or state.inactiveColors
+                if overrides and overrides.subgroups then
+                    state.subgroups = BuildDebuffOverviewSubgroupFilter(overrides.subgroups)
+                end
+                if overrides and overrides.sortByRole ~= nil then
+                    state.sortByRole = overrides.sortByRole == true
+                end
+                if overrides and overrides.showInactive ~= nil then
+                    state.showInactive = overrides.showInactive == true
+                end
+            end
+            if overrides and self.DebuffOverviewContainerPreviewActive and self.DebuffOverviewContainerPreviewName == containerName and self.DebuffOverviewFakePreviewConfig then
+                self.DebuffOverviewFakePreviewConfig.overrides = overrides
+                self.DebuffOverviewFakePreviewConfig.backgroundOnly = overrides.backgroundOnly
+            end
+        end
+        self:UpdateDebuffOverviewContainers()
+        return existingSet
+    end
+    if regularFilter == nil and candidateFilters == nil then
+        return self.DebuffOverviewContainerSetsByName[containerName]
+    end
+    assert(type(regularFilter) == "string" and AuraUtil.IsValidFilterString(regularFilter), "regularFilter must be a valid aura filter string")
+    assert(candidateFilters == nil or type(candidateFilters) == "table", "candidateFilters must be a table or nil")
+    if not C_AddOns.IsAddOnLoaded("Blizzard_AuraContainer") then
+        C_AddOns.LoadAddOn("Blizzard_AuraContainer")
+    end
+
+    local settings = NSRT.ReminderSettings.DebuffOverviewSettings
+    local copies = math.max(1, math.floor(containersPerUnit or 1))
+    local frameCount = maxFrameCount or 1
+    local _, flowAxis, flowAnchor, flowHorizontal, flowVertical = GetDebuffOverviewFlow(settings)
+    local subgroupFilter = BuildDebuffOverviewSubgroupFilter(overrides and overrides.subgroups)
     local containerStates = {}
 
     for raidIndex = 1, 30 do
@@ -2036,6 +2187,11 @@ function NSI:CreateDebuffOverviewContainers(regularFilter, candidateFilters, con
             local height = overrides and overrides.height or settings.Height
             local state = {
                 unit = unit,
+                raidIndex = raidIndex,
+                subgroups = subgroupFilter,
+                sortByRole = overrides and overrides.sortByRole == true,
+                showInactive = overrides and overrides.showInactive == true,
+                inactiveColors = overrides and overrides.inactiveColors,
                 displayName = displayName,
                 invertFill = invertFill == true,
                 useBarColorAsBackground = useBarColorAsBackground == true,
@@ -2060,27 +2216,6 @@ function NSI:CreateDebuffOverviewContainers(regularFilter, candidateFilters, con
             container:SetFlowLayoutAxis(flowAxis)
             container:SetFlowLayoutAnchorPoint(flowAnchor)
             container:SetFlowLayoutGrowthDirection(flowHorizontal, flowVertical)
-            if previousContainer then
-                if growDirection == "Up" then
-                    container:SetPoint("BOTTOMLEFT", previousContainer, "TOPLEFT", 0, settings.Spacing or 0)
-                elseif growDirection == "Down" then
-                    container:SetPoint("TOPLEFT", previousContainer, "BOTTOMLEFT", 0, -(settings.Spacing or 0))
-                elseif growDirection == "Left" then
-                    container:SetPoint("TOPRIGHT", previousContainer, "TOPLEFT", -(settings.Spacing or 0), 0)
-                else
-                    container:SetPoint("TOPLEFT", previousContainer, "TOPRIGHT", settings.Spacing or 0, 0)
-                end
-            else
-                if growDirection == "Up" then
-                    container:SetPoint("BOTTOMLEFT", anchor, "TOPLEFT", 0, 8)
-                elseif growDirection == "Down" then
-                    container:SetPoint("TOPLEFT", anchor, "BOTTOMLEFT", 0, -8)
-                elseif growDirection == "Left" then
-                    container:SetPoint("TOPRIGHT", anchor, "TOPLEFT", -8, 0)
-                else
-                    container:SetPoint("TOPLEFT", anchor, "TOPRIGHT", 8, 0)
-                end
-            end
             container:AddAuraGroup("DebuffOverview", regularFilter, {
                 maxFrameCount = frameCount,
                 sortMethod = state.sortByDuration and AuraContainerSortMethod.ExpirationOnly or (state.useApplicationBar and AuraContainerSortMethod.AuraInstanceIDOnly or nil),
@@ -2098,12 +2233,15 @@ function NSI:CreateDebuffOverviewContainers(regularFilter, candidateFilters, con
             })
             container:Hide()
             container:SetEnabled(false)
+            if state.showInactive then EnsureDebuffOverviewBaseRow(self, state) end
             containerStates[#containerStates + 1] = state
-            previousContainer = container
         end
     end
+    if not self.DebuffOverviewContainerSetsByName[containerName] then
+        self.DebuffOverviewContainerOrder[#self.DebuffOverviewContainerOrder + 1] = containerName
+    end
     self.DebuffOverviewContainerSetsByName[containerName] = containerStates
-    self.DebuffOverviewContainerSets = containerStates
+    self:LayoutDebuffOverviewSets()
     return containerStates
 end
 
@@ -2111,24 +2249,9 @@ function NSI:UpdateDebuffOverviewContainers()
     if self:Restricted() then return end
     local sets = self.DebuffOverviewContainerSetsByName or {}
     local settings = NSRT.ReminderSettings.DebuffOverviewSettings
-    local growDirection = settings.GrowDirection or "Up"
-    local flowHorizontal = AnchorUtil.FlowDirection.Right
-    local flowVertical = AnchorUtil.FlowDirection.Down
-    local flowAxis = AnchorUtil.FlowLayoutAxis.Horizontal
-    local flowAnchor = "TOPLEFT"
-    if growDirection == "Up" then
-        flowAxis = AnchorUtil.FlowLayoutAxis.Vertical
-        flowVertical = AnchorUtil.FlowDirection.Up
-        flowAnchor = "BOTTOMLEFT"
-    elseif growDirection == "Left" then
-        flowHorizontal = AnchorUtil.FlowDirection.Left
-        flowAnchor = "TOPRIGHT"
-    elseif growDirection == "Right" then
-        flowAnchor = "TOPLEFT"
-    end
+    local _, flowAxis, flowAnchor, flowHorizontal, flowVertical = GetDebuffOverviewFlow(settings)
 
     for _, states in pairs(sets) do
-        local previousContainer
         for _, state in ipairs(states) do
             local container = state.container
             local height = state.height or settings.Height
@@ -2147,32 +2270,13 @@ function NSI:UpdateDebuffOverviewContainers()
             elseif state.useApplicationBar then
                 container:SetAuraGroupSortMethod("DebuffOverview", AuraContainerSortMethod.AuraInstanceIDOnly, AuraContainerSortDirection.Normal)
             end
-            container:ClearAllPoints()
-            if previousContainer then
-                if growDirection == "Up" then
-                    container:SetPoint("BOTTOMLEFT", previousContainer, "TOPLEFT", 0, settings.Spacing or 0)
-                elseif growDirection == "Down" then
-                    container:SetPoint("TOPLEFT", previousContainer, "BOTTOMLEFT", 0, -(settings.Spacing or 0))
-                elseif growDirection == "Left" then
-                    container:SetPoint("TOPRIGHT", previousContainer, "TOPLEFT", -(settings.Spacing or 0), 0)
-                else
-                    container:SetPoint("TOPLEFT", previousContainer, "TOPRIGHT", settings.Spacing or 0, 0)
-                end
-            elseif growDirection == "Up" then
-                container:SetPoint("BOTTOMLEFT", self.DebuffOverviewMover, "TOPLEFT", 0, 8)
-            elseif growDirection == "Down" then
-                container:SetPoint("TOPLEFT", self.DebuffOverviewMover, "BOTTOMLEFT", 0, -8)
-            elseif growDirection == "Left" then
-                container:SetPoint("TOPRIGHT", self.DebuffOverviewMover, "TOPLEFT", -8, 0)
-            else
-                container:SetPoint("TOPLEFT", self.DebuffOverviewMover, "TOPRIGHT", 8, 0)
-            end
             for button in pairs(state.buttonRegions) do
                 ConfigureDebuffOverviewButton(self, state, button, state.unit)
             end
-            previousContainer = container
+            if state.showInactive then EnsureDebuffOverviewBaseRow(self, state) end
         end
     end
+    self:LayoutDebuffOverviewSets()
     local previewConfig = self.DebuffOverviewFakePreviewConfig
     if self.DebuffOverviewContainerPreviewActive and previewConfig then
         self:UpdateDebuffOverviewFakePreview(previewConfig.rowCount, previewConfig.useApplicationBar, previewConfig.maxApplications, previewConfig.overrides, previewConfig.backgroundOnly)
@@ -2181,35 +2285,33 @@ end
 
 function NSI:SetDebuffOverviewContainersShown(shown, containerName)
     local sets = self.DebuffOverviewContainerSetsByName or {}
-    if not containerName then
-        if self.DebuffOverviewContainerSets then sets.Default = self.DebuffOverviewContainerSets end
-        containerName = "Default"
-    end
+    containerName = containerName or "Default"
     local states = sets[containerName]
     if not states then return end
     self.DebuffOverviewShownSets = self.DebuffOverviewShownSets or {}
     self.DebuffOverviewShownSets[containerName] = shown
-    if self.DebuffOverviewMover then
+    if self.DebuffOverviewMover and not self.IsInPreview then -- never pull the mover away while anchors are unlocked
         local anyShown = false
         for _, isShown in pairs(self.DebuffOverviewShownSets) do
             if isShown then anyShown = true break end
         end
         self.DebuffOverviewMover:SetShown(anyShown)
     end
-    for _, state in ipairs(states) do
-        local displayName = NSAPI:Shorten(state.unit, nil, false, "GlobalNickNames", true, true) or UnitName(state.unit) or state.unit
-        if not self:Restricted() then
+    if not self:Restricted() then
+        for _, state in ipairs(states) do
+            local displayName = NSAPI:Shorten(state.unit, nil, false, "GlobalNickNames", true, true) or UnitName(state.unit) or state.unit
             state.displayName = displayName
             for button, regions in pairs(state.buttonRegions) do
                 if regions.name then
                     regions.name:SetText(displayName)
                 end
             end
+            if state.baseRow then
+                state.baseRow.Name:SetText(displayName)
+            end
         end
-        local visible = shown and UnitIsVisible(state.unit)
-        state.container:SetShown(visible)
-        state.container:SetEnabled(visible)
     end
+    self:LayoutDebuffOverviewSets()
 end
 
 function NSI:UpdateDebuffOverviewFakePreview(rowCount, useApplicationBar, maxApplications, overrides, backgroundOnly)
@@ -2234,7 +2336,12 @@ function NSI:UpdateDebuffOverviewFakePreview(rowCount, useApplicationBar, maxApp
     local rowWidth = width + height
     local rowHeight = height
     local barAnchorOffset = settings.IconPosition == "Right" and 0 or -height
-    frame:SetSize(vertical and rowWidth or rowCount * (rowWidth + settings.Spacing) - settings.Spacing, vertical and rowCount * (rowHeight + settings.Spacing) - settings.Spacing or rowHeight)
+    local columns = overrides and overrides.previewColumns or {{}}
+    local showInactive = overrides and overrides.showInactive == true
+    local previewActiveRows = 2
+    local columnSpan = #columns * ((vertical and rowWidth or rowHeight) + settings.Spacing) - settings.Spacing
+    local rowSpan = rowCount * ((vertical and rowHeight or rowWidth) + settings.Spacing) - settings.Spacing
+    frame:SetSize(vertical and columnSpan or rowSpan, vertical and rowSpan or columnSpan)
     frame:ClearAllPoints()
     if growDirection == "Up" then
         frame:SetPoint("BOTTOMLEFT", self.DebuffOverviewMover, "TOPLEFT", barAnchorOffset, 8)
@@ -2247,8 +2354,17 @@ function NSI:UpdateDebuffOverviewFakePreview(rowCount, useApplicationBar, maxApp
     end
     local fontPath = self.LSM:Fetch("font", settings.Font)
     local iconInfo = C_Spell.GetSpellInfo(1311611)
-    for index = 1, rowCount do
-        local row = frame.rows[index]
+    for rowIndex = 1, rowCount * #columns do
+        local columnIndex = math.ceil(rowIndex / rowCount)
+        local index = rowIndex - (columnIndex - 1) * rowCount
+        local isActive = not showInactive or index <= previewActiveRows
+        local columnBackgroundColors = columns[columnIndex].backgroundColors or backgroundColors
+        if not isActive then
+            columnBackgroundColors = columns[columnIndex].inactiveColors or columnBackgroundColors
+        end
+        local columnOffsetX = vertical and (columnIndex - 1) * (rowWidth + settings.Spacing) or 0
+        local columnOffsetY = vertical and 0 or -(columnIndex - 1) * (rowHeight + settings.Spacing)
+        local row = frame.rows[rowIndex]
         if not row then
             row = CreateFrame("Frame", nil, frame)
             row.Bar = CreateFrame("StatusBar", nil, row, "BackdropTemplate")
@@ -2260,17 +2376,17 @@ function NSI:UpdateDebuffOverviewFakePreview(rowCount, useApplicationBar, maxApp
             row.Value = row.TextLayer:CreateFontString(nil, "OVERLAY")
             row.Bar:SetBackdrop({bgFile = "Interface\\Buttons\\WHITE8x8"})
             row.Border:SetBackdrop({edgeFile = "Interface\\Buttons\\WHITE8x8", edgeSize = 1})
-            frame.rows[index] = row
+            frame.rows[rowIndex] = row
         end
         row:ClearAllPoints()
         if growDirection == "Up" then
-            row:SetPoint("BOTTOMLEFT", frame, "BOTTOMLEFT", 0, (index - 1) * (height + settings.Spacing))
+            row:SetPoint("BOTTOMLEFT", frame, "BOTTOMLEFT", columnOffsetX, (index - 1) * (height + settings.Spacing))
         elseif growDirection == "Left" then
-            row:SetPoint("TOPRIGHT", frame, "TOPRIGHT", -(index - 1) * (rowWidth + settings.Spacing), 0)
+            row:SetPoint("TOPRIGHT", frame, "TOPRIGHT", -(index - 1) * (rowWidth + settings.Spacing), columnOffsetY)
         elseif growDirection == "Right" then
-            row:SetPoint("TOPLEFT", frame, "TOPLEFT", (index - 1) * (rowWidth + settings.Spacing), 0)
+            row:SetPoint("TOPLEFT", frame, "TOPLEFT", (index - 1) * (rowWidth + settings.Spacing), columnOffsetY)
         else
-            row:SetPoint("TOPLEFT", frame, "TOPLEFT", 0, -(index - 1) * (height + settings.Spacing))
+            row:SetPoint("TOPLEFT", frame, "TOPLEFT", columnOffsetX, -(index - 1) * (height + settings.Spacing))
         end
         row:SetSize(width + height, height)
         row.Bar:ClearAllPoints()
@@ -2286,11 +2402,12 @@ function NSI:UpdateDebuffOverviewFakePreview(rowCount, useApplicationBar, maxApp
         row.Bar:SetStatusBarColor(unpack(barColors))
         row.Bar:SetMinMaxValues(0, useApplicationBar and maxApplications or 8)
         row.Bar:SetValue(backgroundOnly and 0 or (useApplicationBar and (maxApplications - ((index - 1) % maxApplications)) or 8 - ((index - 1) % 8)))
-        row.Bar:SetBackdropColor(unpack(backgroundColors))
-        if useBarColorAsBackground then
-            row.Background:SetAllPoints(row.Bar)
-            row.Background:SetTexture(self.LSM:Fetch("statusbar", settings.Texture))
-            row.Background:SetVertexColor(unpack(fillBackgroundColors))
+        row.Bar:SetBackdropColor(unpack(columnBackgroundColors))
+        if useBarColorAsBackground or not isActive then
+            -- an inactive row has no icon, so its color spans the whole row the way the static row does in game
+            row.Background:SetAllPoints(isActive and row.Bar or row)
+            row.Background:SetTexture(isActive and self.LSM:Fetch("statusbar", settings.Texture) or "Interface\\Buttons\\WHITE8x8")
+            row.Background:SetVertexColor(unpack(columnBackgroundColors or fillBackgroundColors))
             row.Background:Show()
         else
             row.Background:Hide()
@@ -2303,28 +2420,24 @@ function NSI:UpdateDebuffOverviewFakePreview(rowCount, useApplicationBar, maxApp
         row.Name:SetPoint("LEFT", row.Bar, "LEFT", settings.xTextOffset, settings.yTextOffset)
         row.Name:SetFont(fontPath, settings.FontSize, settings.FontFlags)
         row.Name:SetTextColor(unpack(settings.textColors))
-        row.Name:SetText(index == 1 and (NSAPI:Shorten("player", nil, false, "GlobalNickNames", true, true) or "Player") or "Player " .. index)
+        row.Name:SetText(rowIndex == 1 and (NSAPI:Shorten("player", nil, false, "GlobalNickNames", true, true) or "Player") or "Player " .. rowIndex)
         row.Value:SetPoint("RIGHT", row.Bar, "RIGHT", settings.xTimer, settings.yTimer)
         row.Value:SetFont(fontPath, settings.TimerFontSize, settings.FontFlags)
         row.Value:SetTextColor(unpack(settings.textColors))
         row.Value:SetText(useApplicationBar and tostring(maxApplications - ((index - 1) % maxApplications)) or tostring(8 - ((index - 1) % 8)))
-        row.Icon:SetShown(true)
+        row.Icon:SetShown(isActive)
         row.Name:SetShown(true)
-        row.Value:SetShown(not (overrides and overrides.hideValue))
+        row.Value:SetShown(isActive and not (overrides and overrides.hideValue))
         row:Show()
     end
-    for index = rowCount + 1, #frame.rows do frame.rows[index]:Hide() end
+    for index = rowCount * #columns + 1, #frame.rows do frame.rows[index]:Hide() end
     frame:Show()
 end
 
 function NSI:PreviewDebuffOverviewContainers(regularFilter, candidateFilters, containersPerUnit, maxFrameCount, containerName, invertFill, useBarColorAsBackground, useApplicationBar, maxApplications, previewRowCount, overrides, sortByDuration)
     if self.DebuffOverviewContainerPreviewActive then
         self.DebuffOverviewContainerPreviewActive = false
-        local states = self.DebuffOverviewContainerSetsByName and self.DebuffOverviewContainerSetsByName[self.DebuffOverviewContainerPreviewName]
-        for _, state in ipairs(states or {}) do
-            state.container:Hide()
-            state.container:SetEnabled(false)
-        end
+        self:SetDebuffOverviewContainersShown(false, self.DebuffOverviewContainerPreviewName)
         if self.DebuffOverviewFakePreview then self.DebuffOverviewFakePreview:Hide() end
         self.DebuffOverviewContainerPreviewName = nil
         self.DebuffOverviewFakePreviewConfig = nil
@@ -2342,15 +2455,11 @@ function NSI:PreviewDebuffOverviewContainers(regularFilter, candidateFilters, co
         overrides = overrides,
         backgroundOnly = overrides and overrides.backgroundOnly,
     }
-    local states = self.DebuffOverviewContainerSetsByName and self.DebuffOverviewContainerSetsByName[containerName]
-    for _, state in ipairs(states or {}) do
-        state.container:Hide()
-        state.container:SetEnabled(false)
-    end
     if previewRowCount then
+        self:SetDebuffOverviewContainersShown(false, self.DebuffOverviewContainerPreviewName)
         self:UpdateDebuffOverviewFakePreview(previewRowCount, useApplicationBar, maxApplications or 1, overrides, overrides and overrides.backgroundOnly)
     else
-        self:SetDebuffOverviewContainersShown(true, containerName)
+        self:SetDebuffOverviewContainersShown(true, self.DebuffOverviewContainerPreviewName)
     end
 end
 

--- a/NorthernSkyRaidTools/AuraTracking.lua
+++ b/NorthernSkyRaidTools/AuraTracking.lua
@@ -2314,6 +2314,18 @@ function NSI:SetDebuffOverviewContainersShown(shown, containerName)
     self:LayoutDebuffOverviewSets()
 end
 
+function NSI:RefreshDebuffOverviewContainers()
+    if self:Restricted() then
+        self.PendingDebuffOverviewUpdate = true
+        return
+    end
+    self.PendingDebuffOverviewUpdate = nil
+    for containerName in pairs(self.DebuffOverviewContainerSetsByName or {}) do
+        local shown = self.DebuffOverviewShownSets and self.DebuffOverviewShownSets[containerName] or false
+        self:SetDebuffOverviewContainersShown(shown, containerName)
+    end
+end
+
 function NSI:UpdateDebuffOverviewFakePreview(rowCount, useApplicationBar, maxApplications, overrides, backgroundOnly)
     local settings = NSRT.ReminderSettings.DebuffOverviewSettings
     local width = settings.Width

--- a/NorthernSkyRaidTools/EncounterAlerts/MidnightS2/Ulatek.lua
+++ b/NorthernSkyRaidTools/EncounterAlerts/MidnightS2/Ulatek.lua
@@ -212,7 +212,7 @@ NSI.InitializeAlerts[encID] = function(self)
     local data = {group = "Ula'tek", internalID = "GraspingFangsOverview", name = "Grasping Fangs Overview", text = nil, DisplayType = "Bar", encID = encID, phase = 1, TTS = false, dur = 40,
         Version = {versionNumber = 1, [1] = {LeftBackgroundColor = {1, 0, 0, 1}, RightBackgroundColor = {0, 0.45, 1, 1},
             LeftInactiveColor = {0.32, 0.02, 0.02, 0.85}, RightInactiveColor = {0.02, 0.155, 0.32, 0.85},
-            LeftGroups = "1,2,3,4,5,6,7,8", RightGroups = "", SortByRole = true, ShowAllPlayers = true}},
+            LeftGroups = "1,2", RightGroups = "3,4", SortByRole = true, ShowAllPlayers = true}},
         spellID = 1311611, id = 0.2, difficulties = {15, 16}, isSpecialDisplay = true, BlockCopy = true, NoEdit = true, Preview = UlatekGraspingFangsPreview, enabled = false,
         LeftBackgroundColor = {1, 0, 0, 1}, RightBackgroundColor = {0, 0.45, 1, 1}, LeftGroups = "1,2", RightGroups = "3,4", SortByRole = true, extraOptions = graspingFangsOverviewOptions,
         LeftInactiveColor = {0.32, 0.02, 0.02, 0.85}, RightInactiveColor = {0.02, 0.155, 0.32, 0.85}, ShowAllPlayers = true,

--- a/NorthernSkyRaidTools/EncounterAlerts/MidnightS2/Ulatek.lua
+++ b/NorthernSkyRaidTools/EncounterAlerts/MidnightS2/Ulatek.lua
@@ -212,9 +212,9 @@ NSI.InitializeAlerts[encID] = function(self)
     local data = {group = "Ula'tek", internalID = "GraspingFangsOverview", name = "Grasping Fangs Overview", text = nil, DisplayType = "Bar", encID = encID, phase = 1, TTS = false, dur = 40,
         Version = {versionNumber = 1, [1] = {LeftBackgroundColor = {1, 0, 0, 1}, RightBackgroundColor = {0, 0.45, 1, 1},
             LeftInactiveColor = {0.32, 0.02, 0.02, 0.85}, RightInactiveColor = {0.02, 0.155, 0.32, 0.85},
-            LeftGroups = "1,2,3,4,5,6,7,8", RightGroups = "", SortByRole = false, ShowAllPlayers = true}},
+            LeftGroups = "1,2,3,4,5,6,7,8", RightGroups = "", SortByRole = true, ShowAllPlayers = true}},
         spellID = 1311611, id = 0.2, difficulties = {15, 16}, isSpecialDisplay = true, BlockCopy = true, NoEdit = true, Preview = UlatekGraspingFangsPreview, enabled = false,
-        LeftBackgroundColor = {1, 0, 0, 1}, RightBackgroundColor = {0, 0.45, 1, 1}, LeftGroups = "1,2,3,4,5,6,7,8", RightGroups = "", SortByRole = false, extraOptions = graspingFangsOverviewOptions,
+        LeftBackgroundColor = {1, 0, 0, 1}, RightBackgroundColor = {0, 0.45, 1, 1}, LeftGroups = "1,2", RightGroups = "3,4", SortByRole = true, extraOptions = graspingFangsOverviewOptions,
         LeftInactiveColor = {0.32, 0.02, 0.02, 0.85}, RightInactiveColor = {0.02, 0.155, 0.32, 0.85}, ShowAllPlayers = true,
         timers = {
             [15] = {180},

--- a/NorthernSkyRaidTools/EncounterAlerts/MidnightS2/Ulatek.lua
+++ b/NorthernSkyRaidTools/EncounterAlerts/MidnightS2/Ulatek.lua
@@ -3,6 +3,59 @@ local _, NSI = ... -- Internal namespace
 local encID = 3492
 -- /run NSAPI:DebugEncounter(3492)
 
+local GRASPING_FANGS_LEFT = "UlatekGraspingFangsLeftSide"
+local GRASPING_FANGS_RIGHT = "UlatekGraspingFangsRightSide"
+
+local function GetGraspingFangsAlert()
+    local diffData = NSRT.EncounterAlerts[encID] and NSRT.EncounterAlerts[encID][16]
+    return diffData and diffData.GraspingFangsOverview
+end
+
+-- Each side gets its own subgroup string like "1,2"/"3,4" or "1,3,5,7"/"2,4,6,8"
+local function ParseGroupList(text)
+    local subgroups = {}
+    for value in tostring(text or ""):gmatch("%d+") do
+        subgroups[#subgroups + 1] = tonumber(value)
+    end
+    return subgroups
+end
+
+local function BuildGraspingFangsOverrides(alert, isLeftSide)
+    local rightGroups = ParseGroupList(alert.RightGroups)
+    local previewColumns = {{backgroundColors = alert.LeftBackgroundColor, inactiveColors = alert.LeftInactiveColor}}
+    if #rightGroups > 0 then previewColumns[2] = {backgroundColors = alert.RightBackgroundColor, inactiveColors = alert.RightInactiveColor} end
+    return {
+        backgroundColors = isLeftSide and alert.LeftBackgroundColor or alert.RightBackgroundColor,
+        inactiveColors = isLeftSide and alert.LeftInactiveColor or alert.RightInactiveColor,
+        showInactive = alert.ShowAllPlayers ~= false,
+        height = alert.BarHeight,
+        subgroups = isLeftSide and ParseGroupList(alert.LeftGroups) or rightGroups,
+        sortByRole = alert.SortByRole == true,
+        backgroundOnly = true,
+        hideValue = true,
+        previewColumns = previewColumns,
+    }
+end
+
+function NSI:UpdateUlatekGraspingFangsOverviews(alert)
+    alert = alert or GetGraspingFangsAlert()
+    if not alert then return end
+    self:CreateDebuffOverviewContainers("HARMFUL|!PLAYER|!DISPELLABLE", {isBossAura = true}, 1, 1, GRASPING_FANGS_LEFT, false, true, false, 1, BuildGraspingFangsOverrides(alert, true))
+    self:CreateDebuffOverviewContainers("HARMFUL|!PLAYER|!DISPELLABLE", {isBossAura = true}, 1, 1, GRASPING_FANGS_RIGHT, false, true, false, 1, BuildGraspingFangsOverrides(alert, false))
+end
+
+function NSI:SetUlatekGraspingFangsOverviewsShown(shown)
+    self:SetDebuffOverviewContainersShown(shown, GRASPING_FANGS_LEFT)
+    self:SetDebuffOverviewContainersShown(shown, GRASPING_FANGS_RIGHT)
+end
+
+function NSI:PreviewUlatekGraspingFangsOverviews()
+    local alert = GetGraspingFangsAlert()
+    if not alert then return end
+    self:UpdateUlatekGraspingFangsOverviews(alert)
+    self:PreviewDebuffOverviewContainers(nil, nil, nil, nil, GRASPING_FANGS_LEFT, false, true, false, 1, 6, BuildGraspingFangsOverrides(alert, true))
+end
+
 NSI.InitializeAlerts[encID] = function(self)
     NSRT.EncounterAlerts[encID] = NSRT.EncounterAlerts[encID] or {}
     for i = 14, 16 do
@@ -121,28 +174,48 @@ NSI.InitializeAlerts[encID] = function(self)
     }
     self:AddEncounterAlert(data)
 
-    local UlatekGraspingFangsPreview = [[
-        return function(self)
-            local alert = NSRT.EncounterAlerts[3492][16].GraspingFangsOverview
-            local overviewSettings = NSRT.ReminderSettings.DebuffOverviewSettings
-            self:PreviewDebuffOverviewContainers("HARMFUL|!PLAYER|!DISPELLABLE", {isBossAura = true}, 1, 1, "UlatekGraspingFangsOverview", false, true, false, 1, 6, {
-                backgroundColors = alert.BackgroundColor or {1, 0, 0, 1},
-                height = alert.BarHeight or overviewSettings.Height,
-                backgroundOnly = true,
-                hideValue = true,
-            })
-        end
-    ]]
+    local UlatekGraspingFangsPreview = [[return function(self) self:PreviewUlatekGraspingFangsOverviews() end]]
     local graspingFangsOverviewOptions = {
-        {Type = "Color", label = "Background Color",
-            get = [[return function() local a = NSRT.EncounterAlerts[3492][16].GraspingFangsOverview local c = a.BackgroundColor or {1, 0, 0, 1} return c[1], c[2], c[3], c[4] end]],
-            set = [[return function(NSI, r, g, b, a) for i = 15, 16 do NSRT.EncounterAlerts[3492][i].GraspingFangsOverview.BackgroundColor = {r, g, b, a} end NSI:CreateDebuffOverviewContainers("HARMFUL|!PLAYER|!DISPELLABLE", {isBossAura = true}, 1, 1, "UlatekGraspingFangsOverview", false, true, false, 1, {backgroundColors = {r, g, b, a}}) end]],},
+        {Type = "Color", label = "Left Side Background Color",
+            get = [[return function() local a = NSRT.EncounterAlerts[3492][16].GraspingFangsOverview local c = a.LeftBackgroundColor or {1, 0, 0, 1} return c[1], c[2], c[3], c[4] end]],
+            set = [[return function(NSI, r, g, b, a) for i = 15, 16 do NSRT.EncounterAlerts[3492][i].GraspingFangsOverview.LeftBackgroundColor = {r, g, b, a} end NSI:UpdateUlatekGraspingFangsOverviews() end]],},
+        {Type = "Color", label = "Right Side Background Color",
+            get = [[return function() local a = NSRT.EncounterAlerts[3492][16].GraspingFangsOverview local c = a.RightBackgroundColor or {0, 0.45, 1, 1} return c[1], c[2], c[3], c[4] end]],
+            set = [[return function(NSI, r, g, b, a) for i = 15, 16 do NSRT.EncounterAlerts[3492][i].GraspingFangsOverview.RightBackgroundColor = {r, g, b, a} end NSI:UpdateUlatekGraspingFangsOverviews() end]],},
+        {Type = "Color", label = "Left Side Inactive Color",
+            get = [[return function() local a = NSRT.EncounterAlerts[3492][16].GraspingFangsOverview local c = a.LeftInactiveColor or {0.32, 0.02, 0.02, 0.85} return c[1], c[2], c[3], c[4] end]],
+            set = [[return function(NSI, r, g, b, a) for i = 15, 16 do NSRT.EncounterAlerts[3492][i].GraspingFangsOverview.LeftInactiveColor = {r, g, b, a} end NSI:UpdateUlatekGraspingFangsOverviews() end]],
+            tooltip = {title = "Left Side Inactive Color", desc = "Color of the left side's rows while that player does not have the debuff."}},
+        {Type = "Color", label = "Right Side Inactive Color",
+            get = [[return function() local a = NSRT.EncounterAlerts[3492][16].GraspingFangsOverview local c = a.RightInactiveColor or {0.02, 0.155, 0.32, 0.85} return c[1], c[2], c[3], c[4] end]],
+            set = [[return function(NSI, r, g, b, a) for i = 15, 16 do NSRT.EncounterAlerts[3492][i].GraspingFangsOverview.RightInactiveColor = {r, g, b, a} end NSI:UpdateUlatekGraspingFangsOverviews() end]],
+            tooltip = {title = "Right Side Inactive Color", desc = "Color of the right side's rows while that player does not have the debuff."}},
+        {Type = "Checkbox", label = "Show All Players",
+            get = [[return function() local a = NSRT.EncounterAlerts[3492][16].GraspingFangsOverview return a.ShowAllPlayers ~= false end]],
+            set = [[return function(NSI, value) for i = 15, 16 do NSRT.EncounterAlerts[3492][i].GraspingFangsOverview.ShowAllPlayers = value and true or false end NSI:UpdateUlatekGraspingFangsOverviews() end]],
+            tooltip = {title = "Show All Players", desc = "Keeps a row up for every player on that side, in the inactive color, and switches it to the regular color while they have the debuff. Turn off to only show players who currently have the debuff."}},
+        {Type = "TextEntry", label = "Left Side Groups", inputWidth = 120,
+            get = [[return function() return NSRT.EncounterAlerts[3492][16].GraspingFangsOverview.LeftGroups or "1,2,3,4,5,6,7,8" end]],
+            set = [[return function(NSI, value) for i = 15, 16 do NSRT.EncounterAlerts[3492][i].GraspingFangsOverview.LeftGroups = value end NSI:UpdateUlatekGraspingFangsOverviews() end]],
+            tooltip = {title = "Left Side Groups", desc = "Raid subgroups shown on the left side, comma separated. Use 1,2 and 3,4 to split by halves, or 1,3,5,7 and 2,4,6,8 for odds and evens."}},
+        {Type = "TextEntry", label = "Right Side Groups", inputWidth = 120,
+            get = [[return function() return NSRT.EncounterAlerts[3492][16].GraspingFangsOverview.RightGroups or "" end]],
+            set = [[return function(NSI, value) for i = 15, 16 do NSRT.EncounterAlerts[3492][i].GraspingFangsOverview.RightGroups = value end NSI:UpdateUlatekGraspingFangsOverviews() end]],
+            tooltip = {title = "Right Side Groups", desc = "Raid subgroups shown on the right side, comma separated. Empty by default, so only the left side is shown. A group left out of both sides is not tracked."}},
+        {Type = "Checkbox", label = "Sort by Role",
+            get = [[return function() local a = NSRT.EncounterAlerts[3492][16].GraspingFangsOverview return a.SortByRole == true end]],
+            set = [[return function(NSI, value) for i = 15, 16 do NSRT.EncounterAlerts[3492][i].GraspingFangsOverview.SortByRole = value and true or false end NSI:UpdateUlatekGraspingFangsOverviews() end]],},
         {Type = "Slider", label = "Bar Height", min = 10, max = 100, step = 1,
             get = [[return function() local a = NSRT.EncounterAlerts[3492][16].GraspingFangsOverview return a.BarHeight or NSRT.ReminderSettings.DebuffOverviewSettings.Height end]],
-            set = [[return function(NSI, value) for i = 15, 16 do NSRT.EncounterAlerts[3492][i].GraspingFangsOverview.BarHeight = value end NSI:CreateDebuffOverviewContainers("HARMFUL|!PLAYER|!DISPELLABLE", {isBossAura = true}, 1, 1, "UlatekGraspingFangsOverview", false, true, false, 1, {height = value}) end]],},
+            set = [[return function(NSI, value) for i = 15, 16 do NSRT.EncounterAlerts[3492][i].GraspingFangsOverview.BarHeight = value end NSI:UpdateUlatekGraspingFangsOverviews() end]],},
     }
     local data = {group = "Ula'tek", internalID = "GraspingFangsOverview", name = "Grasping Fangs Overview", text = nil, DisplayType = "Bar", encID = encID, phase = 1, TTS = false, dur = 40,
-        spellID = 1311611, id = 0.2, difficulties = {15, 16}, isSpecialDisplay = true, BlockCopy = true, NoEdit = true, Preview = UlatekGraspingFangsPreview, enabled = false, BackgroundColor = {1, 0, 0, 1}, extraOptions = graspingFangsOverviewOptions,
+        Version = {versionNumber = 1, [1] = {LeftBackgroundColor = {1, 0, 0, 1}, RightBackgroundColor = {0, 0.45, 1, 1},
+            LeftInactiveColor = {0.32, 0.02, 0.02, 0.85}, RightInactiveColor = {0.02, 0.155, 0.32, 0.85},
+            LeftGroups = "1,2,3,4,5,6,7,8", RightGroups = "", SortByRole = false, ShowAllPlayers = true}},
+        spellID = 1311611, id = 0.2, difficulties = {15, 16}, isSpecialDisplay = true, BlockCopy = true, NoEdit = true, Preview = UlatekGraspingFangsPreview, enabled = false,
+        LeftBackgroundColor = {1, 0, 0, 1}, RightBackgroundColor = {0, 0.45, 1, 1}, LeftGroups = "1,2,3,4,5,6,7,8", RightGroups = "", SortByRole = false, extraOptions = graspingFangsOverviewOptions,
+        LeftInactiveColor = {0.32, 0.02, 0.02, 0.85}, RightInactiveColor = {0.02, 0.155, 0.32, 0.85}, ShowAllPlayers = true,
         timers = {
             [15] = {180},
             [16] = {180},
@@ -163,18 +236,18 @@ NSI.EncounterAlertStart[encID] = function(self, id)
     end
 
     if overviewAlert and overviewAlert.enabled and self:EvaluateLoad(overviewAlert) then
-        self:CreateDebuffOverviewContainers("HARMFUL|!PLAYER|!DISPELLABLE", {isBossAura = true}, 1, 1, "UlatekGraspingFangsOverview", false, true, false, 1, {backgroundColors = overviewAlert.BackgroundColor or {1, 0, 0, 1}, height = overviewAlert.BarHeight})
+        self:UpdateUlatekGraspingFangsOverviews(overviewAlert)
         self.UlatekGraspingFangsTimers = {}
         for _, applyTime in ipairs(overviewAlert.timers or {}) do
             self.UlatekGraspingFangsTimers[#self.UlatekGraspingFangsTimers + 1] = C_Timer.NewTimer(applyTime, function()
-                if self.EncounterID == encID then self:SetDebuffOverviewContainersShown(true, "UlatekGraspingFangsOverview") end
+                if self.EncounterID == encID then self:SetUlatekGraspingFangsOverviewsShown(true) end
             end)
             self.UlatekGraspingFangsTimers[#self.UlatekGraspingFangsTimers + 1] = C_Timer.NewTimer(applyTime + (overviewAlert.dur or 40), function()
-                if self.EncounterID == encID then self:SetDebuffOverviewContainersShown(false, "UlatekGraspingFangsOverview") end
+                if self.EncounterID == encID then self:SetUlatekGraspingFangsOverviewsShown(false) end
             end)
         end
     else
-        self:SetDebuffOverviewContainersShown(false, "UlatekGraspingFangsOverview")
+        self:SetUlatekGraspingFangsOverviewsShown(false)
     end
 
     if not wrongTargetAlert or not wrongTargetAlert.enabled or not self:EvaluateLoad(wrongTargetAlert) then return end
@@ -259,7 +332,7 @@ NSI.EncounterAlertStop[encID] = function(self)
         for _, timer in ipairs(self.UlatekGraspingFangsTimers) do timer:Cancel() end
         self.UlatekGraspingFangsTimers = nil
     end
-    self:SetDebuffOverviewContainersShown(false, "UlatekGraspingFangsOverview")
+    self:SetUlatekGraspingFangsOverviewsShown(false)
     if self.UlatekWrongTargetTimers then
         for _, timer in ipairs(self.UlatekWrongTargetTimers) do timer:Cancel() end
         self.UlatekWrongTargetTimers = nil

--- a/NorthernSkyRaidTools/EventHandler.lua
+++ b/NorthernSkyRaidTools/EventHandler.lua
@@ -16,6 +16,7 @@ f:RegisterEvent("GROUP_ROSTER_UPDATE")
 f:RegisterEvent("PLAYER_ENTERING_WORLD")
 f:RegisterEvent("PLAYER_LOGOUT")
 f:RegisterEvent("PLAYER_REGEN_ENABLED")
+f:RegisterEvent("ADDON_RESTRICTION_STATE_CHANGED")
 f:RegisterEvent("ACTIVE_PLAYER_SPECIALIZATION_CHANGED")
 
 function NSI:UpdateDebugLogEvents()
@@ -348,10 +349,7 @@ function NSI:EventHandler(e, wowevent, internal, ...) -- internal checks whether
             self.GroupUpdateTimer = nil
             self:InitAuraSystem(false, true)
             if self:DifficultyCheck({14, 15, 16}) then
-                for containerName in pairs(self.DebuffOverviewContainerSetsByName or {}) do
-                    local shown = self.DebuffOverviewShownSets and self.DebuffOverviewShownSets[containerName] or false
-                    self:SetDebuffOverviewContainersShown(shown, containerName)
-                end
+                self:RefreshDebuffOverviewContainers()
             end
             self:UpdateRaidBuffFrame()
         end)
@@ -367,10 +365,16 @@ function NSI:EventHandler(e, wowevent, internal, ...) -- internal checks whether
                 end)
             end
         end
+    elseif e == "ADDON_RESTRICTION_STATE_CHANGED" and wowevent then
+        local restrictionState = select(2, ...)
+        if restrictionState == Enum.AddOnRestrictionState.Inactive then
+            self:RefreshDebuffOverviewContainers()
+        end
     elseif e == "PLAYER_REGEN_ENABLED" and wowevent then
         if self.PendingAuraTrackingUpdate then
             self:InitAuraTracking(false, self.PendingAuraTrackingReconfigure)
         end
+        self:RefreshDebuffOverviewContainers()
     elseif e == "ACTIVE_PLAYER_SPECIALIZATION_CHANGED" and wowevent then
         self:InitAuraTracking()
     elseif e == "ENCOUNTER_TIMELINE_EVENT_ADDED" and wowevent then

--- a/NorthernSkyRaidTools/Locales/enUS.lua
+++ b/NorthernSkyRaidTools/Locales/enUS.lua
@@ -1209,6 +1209,14 @@ L["Bar Color"] = "Bar Color"
 L["Bar Width"] = "Bar Width"
 L["Bar Height"] = "Bar Height"
 L["Background Color"] = "Background Color"
+L["Left Side Background Color"] = "Left Side Background Color"
+L["Right Side Background Color"] = "Right Side Background Color"
+L["Left Side Inactive Color"] = "Left Side Inactive Color"
+L["Right Side Inactive Color"] = "Right Side Inactive Color"
+L["Left Side Groups"] = "Left Side Groups"
+L["Right Side Groups"] = "Right Side Groups"
+L["Sort by Role"] = "Sort by Role"
+L["Show All Players"] = "Show All Players"
 -- ============================================================================
 -- EncounterAlerts.lua
 -- ============================================================================


### PR DESCRIPTION
## Notes
* Tested in heroic
* 90% vibed again. ty claude
* Intent is that if you have all of the new settings turned off, everything behaves the same as it currently does.

## Features
* left/right side split
* sorted by role (tank, melee, range, healer)
* `Show All Players` setting. If enabled, shows a list of everyone on either side and colors their entries when they have a debuff. (liquid style)

## Screenshots
<img width="790" height="314" alt="image" src="https://github.com/user-attachments/assets/ba270685-0ca3-4ac0-a7cd-d54a13d6c9eb" />
<img width="632" height="339" alt="image" src="https://github.com/user-attachments/assets/a03af035-bc86-4ba1-8986-a1af9cbe9d31" />