### PR TITLE
Fix Ula'tek reminders not showing up with TimelineReminders

### DIFF
--- a/NorthernSkyRaidTools/EncounterAlerts/MidnightS2/Ulatek.lua
+++ b/NorthernSkyRaidTools/EncounterAlerts/MidnightS2/Ulatek.lua
@@ -85,7 +85,7 @@ local function ShowUlatekWaveText(self, alert, text, duration, key, isPreview)
         countdown = false,
         IsAlert = false,
         ReloeReminder = true,
-    }, isPreview)
+    }, true)
     if not info then return end
     local frame = self:DisplayReminder(info, isPreview)
     if key then self[key] = {frame = frame, info = info} end
@@ -929,7 +929,7 @@ NSI.EncounterAlertStart[encID] = function(self, id, isPreview)
                                     TTSTimer = transitionSoakAlert.TTSTimer,
                                     IsAlert = false,
                                     ReloeReminder = true,
-                                })
+                                }, true)
                                 if info then self:DisplayReminder(info) end
                             end)
                         end
@@ -1157,7 +1157,7 @@ NSI.EncounterAlertStart[encID] = function(self, id, isPreview)
             TTS = false,
             IsAlert = false,
             ReloeReminder = true,
-        })
+        }, true)
         self.UlatekWrongTargetFrame = info and self:DisplayReminder(info)
     end
 


### PR DESCRIPTION
some Ula'tek reminders like Wave Direction were not showing up for people that did reminders through TR.

apparently, "preview" means "build this reminder for NSRT only and never hand it off to the timeline addon"